### PR TITLE
Add npm policy checks to infra scanner

### DIFF
--- a/skill/checksums.json
+++ b/skill/checksums.json
@@ -20,7 +20,7 @@
     "scripts/scan_dependencies.py": "b96c4137486d5988a6c09b1db10b8b70601abb766639dea28b8632b5b6c88250",
     "scripts/scan_entropy.py": "c27a83523d4b9b63b880d948aa60ab269b6ab340fb2a5cd325c705495b4e5712",
     "scripts/scan_git_forensics.py": "ac4c2944f3a2eff15bc63896d50b8ed862e7fa513532d83043e073449063903b",
-    "scripts/scan_infra.py": "c04a2a99195337f468c5281be472bb4f7514c026c82324e74cfe2d8f64798f79",
+    "scripts/scan_infra.py": "1b5c40cef2c2084f142302dde54ef384d873366e5c68d06b350e954cb291b713",
     "scripts/scan_integrity.py": "86f0b73e1ff2e9e56a5bfb32ca23aaeff4d2c41e0dabafdcd03145ee81e2d1d2",
     "scripts/scan_lifecycle.py": "c214700f8e670edfe0621307f8f2153664be3339780ca2982655956fb8d95089",
     "scripts/scan_manifest_drift.py": "105de3be2564e8d2f7671b4e473bf59118c4eacb1f00683a2827cd80e1d2e854",

--- a/skill/scripts/scan_infra.py
+++ b/skill/scripts/scan_infra.py
@@ -197,7 +197,7 @@ def scan_github_actions(file_path, rel_path):
                     category="ci-cd"
                 ))
 
-            if re.search(r'\brun\s*:\s*(?:.+\s)?npm\s+(?:install|i)\b', stripped):
+            if re.search(r'\brun\s*:\s*(?:.+\s)?npm\s+(?:install|i)(?=\s|$)', stripped):
                 findings.append(core.Finding(
                     scanner=SCANNER_NAME, severity="medium",
                     title="GHA: npm install in Workflow",
@@ -230,7 +230,7 @@ def scan_github_actions(file_path, rel_path):
                         category="ci-cd"
                     ))
                     break
-            if re.search(r'\bnpm\s+(?:install|i)\b', block):
+            if re.search(r'\bnpm\s+(?:install|i)(?=\s|$)', block):
                 findings.append(core.Finding(
                     scanner=SCANNER_NAME, severity="medium",
                     title="GHA: npm install in Multi-line Run Block",

--- a/skill/tests/test_scan_infra.py
+++ b/skill/tests/test_scan_infra.py
@@ -63,6 +63,22 @@ class TestGitHubActions:
         findings = scanner.scan_github_actions(str(ci), ".github/workflows/ci.yml")
         assert any("npm install" in f.title.lower() for f in findings)
 
+    def test_does_not_flag_npm_install_ci_test_single_line(self, tmp_path):
+        workflow = tmp_path / ".github" / "workflows"
+        workflow.mkdir(parents=True)
+        ci = workflow / "ci.yml"
+        ci.write_text(
+            "name: CI\n"
+            "on: [push]\n"
+            "jobs:\n"
+            "  build:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - run: npm install-ci-test\n"
+        )
+        findings = scanner.scan_github_actions(str(ci), ".github/workflows/ci.yml")
+        assert not any("npm install" in f.title.lower() for f in findings)
+
     def test_detects_npm_install_in_multiline_run_block(self, tmp_path):
         workflow = tmp_path / ".github" / "workflows"
         workflow.mkdir(parents=True)
@@ -80,6 +96,24 @@ class TestGitHubActions:
         )
         findings = scanner.scan_github_actions(str(ci), ".github/workflows/ci.yml")
         assert any("multi-line run block" in f.title.lower() for f in findings)
+
+    def test_does_not_flag_npm_install_ci_test_multiline(self, tmp_path):
+        workflow = tmp_path / ".github" / "workflows"
+        workflow.mkdir(parents=True)
+        ci = workflow / "ci.yml"
+        ci.write_text(
+            "name: CI\n"
+            "on: [push]\n"
+            "jobs:\n"
+            "  build:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - run: |\n"
+            "          npm install-ci-test\n"
+            "          echo done\n"
+        )
+        findings = scanner.scan_github_actions(str(ci), ".github/workflows/ci.yml")
+        assert not any("npm install" in f.title.lower() for f in findings)
 
 
 class TestNpmrc:


### PR DESCRIPTION
## Summary
- flag GitHub Actions workflows that use `npm install` instead of `npm ci`
- extend `.npmrc` scanning to detect missing `allow-git=none`
- extend `.npmrc` scanning to detect missing `min-release-age>=3`
- add focused infra-scanner tests for the new npm policy findings

## Why
repo-forensics already covers npm hardening signals like missing lockfiles, git dependencies, and missing `ignore-scripts=true`. These additions tighten the same policy surface without moving the project into remediation.

The new checks catch:
- weaker CI install policy in workflows (`npm install` vs `npm ci`)
- missing protection against git dependency lifecycle bypasses (`allow-git=none`)
- missing package cooldown policy for newly published versions (`min-release-age`)

## Validation
- `pytest -q skill/tests/test_scan_infra.py`
