### PR TITLE
docs: add Sponsor badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   <img src="https://img.shields.io/badge/scanners-18-orange.svg" alt="18 Scanners">
   <img src="https://img.shields.io/badge/patterns-450%2B-red.svg" alt="450+ Patterns">
   <img src="https://img.shields.io/badge/2026%20CVEs-covered-critical.svg" alt="2026 CVEs">
+  <a href="https://github.com/sponsors/alexgreensh"><img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4.svg?labelColor=262626" alt="Sponsor"></a>
 </p>
 
 ---


### PR DESCRIPTION
Adds a pink-heart Sponsor badge to the badge row in the README, matching the style used by Cognee and others in the AI-agent ecosystem.

Links to https://github.com/sponsors/alexgreensh which is already live (`.github/FUNDING.yml` has been in place). This just puts the ask in the body of the README where visitors land, not just the sidebar.

## Preview

![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4.svg?labelColor=262626)

## Diff

```diff
+  <a href="https://github.com/sponsors/alexgreensh"><img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4.svg?labelColor=262626" alt="Sponsor"></a>
```

One-line change, no code touched. README only.

Generated with [Claude Code](https://claude.com/claude-code)