### PR TITLE
Fix npm cache content matching in post-incident scanner

### DIFF
--- a/skills/repo-forensics/scripts/scan_post_incident.py
+++ b/skills/repo-forensics/scripts/scan_post_incident.py
@@ -135,7 +135,7 @@ def scan_npm_cache():
                     # Entirely malicious packages (any version)
                     for pkg_name, desc in MALICIOUS_PACKAGES.items():
                         # Match on tarball URL pattern to avoid substring false positives
-                        if f"/{pkg_name}/-/" in content or f"/{pkg_name}" in content.split('"key"')[0:1]:
+                        if f"/{pkg_name}/-/" in content or f"/{pkg_name}" in content.split('"key"')[0]:
                             findings.append(core.Finding(
                                 scanner=SCANNER_NAME, severity="critical",
                                 title=f"Compromised Package in npm Cache: {pkg_name}",

--- a/skills/repo-forensics/tests/test_scan_post_incident.py
+++ b/skills/repo-forensics/tests/test_scan_post_incident.py
@@ -31,6 +31,63 @@ class TestNodeModulesArtifacts:
         assert any("claud-code" in f.title for f in findings)
 
 
+class TestNpmCacheArtifacts:
+    def test_detects_malicious_package_in_cache_pre_key_substring(self, tmp_path, monkeypatch):
+        """npm cache index entry with package name before the 'key' token is flagged.
+
+        This test exercises the second OR branch exclusively:
+            f"/{pkg_name}" in content.split('"key"')[0]
+        The content intentionally omits the '/-/' tarball URL pattern so the
+        first branch cannot fire. With the buggy '[0:1]' slice the branch
+        returns a list and 'in' checks element equality (always False). With
+        the correct '[0]' it returns a string and substring matching works.
+        """
+        fake_cache = tmp_path / ".npm" / "_cacache"
+        index_dir = fake_cache / "index-v5" / "ab"
+        index_dir.mkdir(parents=True)
+        # content-v2 dir must exist for scan_npm_cache to proceed
+        (fake_cache / "content-v2").mkdir(parents=True)
+
+        # Package name appears BEFORE '"key"' and NO '/-/' tarball pattern present.
+        # content.split('"key"')[0] == '\t{"path":"/plain-crypto-js","'
+        # which contains '/plain-crypto-js', triggering the finding.
+        cache_entry = index_dir / "abc123"
+        cache_entry.write_text(
+            '\t{"path":"/plain-crypto-js","key":"some-cache-key","integrity":"sha512-abc"}'
+        )
+
+        monkeypatch.setattr(
+            scanner.os.path, "expanduser",
+            lambda p: str(tmp_path) if p == "~" else p.replace("~", str(tmp_path))
+        )
+
+        findings = scanner.scan_npm_cache()
+        assert any(
+            "plain-crypto-js" in f.title and f.severity == "critical"
+            for f in findings
+        ), f"Expected critical finding for plain-crypto-js in npm cache, got: {findings}"
+
+    def test_clean_npm_cache_no_findings(self, tmp_path, monkeypatch):
+        """npm cache index with only legitimate packages produces no findings."""
+        fake_cache = tmp_path / ".npm" / "_cacache"
+        index_dir = fake_cache / "index-v5" / "cd"
+        index_dir.mkdir(parents=True)
+        (fake_cache / "content-v2").mkdir(parents=True)
+
+        cache_entry = index_dir / "def456"
+        cache_entry.write_text(
+            '\t{"path":"/lodash","key":"some-cache-key","integrity":"sha512-xyz"}'
+        )
+
+        monkeypatch.setattr(
+            scanner.os.path, "expanduser",
+            lambda p: str(tmp_path) if p == "~" else p.replace("~", str(tmp_path))
+        )
+
+        findings = scanner.scan_npm_cache()
+        assert len(findings) == 0, f"Expected no findings for clean cache, got: {findings}"
+
+
 class TestHostArtifacts:
     def test_no_rat_binary(self):
         """On a clean machine, no RAT binaries should be found."""


### PR DESCRIPTION
content.split("key")[0:1] returns a list. Python in on a list checks element equality, not substring. This branch never matches any package name, making the entire npm cache malicious-package scan non-functional. Replaced with content.split("key")[0] to get the first string segment.