### PR TITLE
Fix OSV severity handling and narrow exception catches in vuln_feed.py

### DIFF
--- a/skills/repo-forensics/scripts/vuln_feed.py
+++ b/skills/repo-forensics/scripts/vuln_feed.py
@@ -477,12 +477,24 @@ def check_package_vulnerabilities(ecosystem, name, version,
     return out
 
 
+_SEVERITY_LABEL_MAP = {
+    "CRITICAL": "critical",
+    "HIGH": "high",
+    "MEDIUM": "medium",
+    "LOW": "low",
+}
+
+
 def _suggest_severity(vuln, in_kev):
     """Map OSV severity + KEV presence to our scanner's severity tiers."""
     if in_kev:
         return "critical"
     sev = vuln.get("severity") or {}
     score_str = sev.get("score", "")
+    # OSV sometimes returns a plain label ("CRITICAL") instead of a CVSS vector.
+    label = _SEVERITY_LABEL_MAP.get(score_str.upper() if isinstance(score_str, str) else "")
+    if label is not None:
+        return label
     # CVSS vector strings start with "CVSS:3.x/..." — extract basescore if present
     # Also tolerate plain numeric strings.
     cvss = _parse_cvss_score(score_str)
@@ -569,9 +581,11 @@ def fetch_npm_freshness(name, version, cache_dir=None, offline=False):
     try:
         raw = _https_fetch(url, NPM_REGISTRY_MAX_BYTES)
         data = json.loads(raw.decode("utf-8"))
-    except Exception as e:
+    except (urllib.error.URLError, json.JSONDecodeError, OSError, ValueError) as e:
         print(f"[!] npm freshness fetch failed for {name}@{version}: {e}",
               file=sys.stderr)
+        return None
+    if not isinstance(data, dict):
         return None
 
     try:
@@ -615,7 +629,7 @@ def fetch_npm_freshness(name, version, cache_dir=None, offline=False):
             "maintainer": maintainer,
             "prev_maintainer": prev_maintainer,
         }
-    except Exception as e:
+    except (urllib.error.URLError, json.JSONDecodeError, OSError, ValueError) as e:
         print(f"[!] npm freshness parse failed for {name}@{version}: {e}",
               file=sys.stderr)
         return None
@@ -663,9 +677,11 @@ def fetch_pypi_freshness(name, version, cache_dir=None, offline=False):
     try:
         raw = _https_fetch(url, PYPI_REGISTRY_MAX_BYTES)
         data = json.loads(raw.decode("utf-8"))
-    except Exception as e:
+    except (urllib.error.URLError, json.JSONDecodeError, OSError, ValueError) as e:
         print(f"[!] PyPI freshness fetch failed for {name}@{version}: {e}",
               file=sys.stderr)
+        return None
+    if not isinstance(data, dict):
         return None
 
     try:
@@ -712,7 +728,7 @@ def fetch_pypi_freshness(name, version, cache_dir=None, offline=False):
             "maintainer": maintainer,
             "prev_maintainer": prev_maintainer,
         }
-    except Exception as e:
+    except (urllib.error.URLError, json.JSONDecodeError, OSError, ValueError) as e:
         print(f"[!] PyPI freshness parse failed for {name}@{version}: {e}",
               file=sys.stderr)
         return None

--- a/skills/repo-forensics/tests/test_vuln_feed.py
+++ b/skills/repo-forensics/tests/test_vuln_feed.py
@@ -403,6 +403,39 @@ def test_check_package_vulnerabilities_non_kev_cve(monkeypatch, tmp_path):
     assert result[0]["suggested_severity"] == "high"
 
 
+@pytest.mark.parametrize("label,expected", [
+    ("CRITICAL", "critical"),
+    ("HIGH", "high"),
+    ("MEDIUM", "medium"),
+    ("LOW", "low"),
+    ("critical", "critical"),   # lowercase label also maps correctly
+])
+def test_severity_label_without_cvss_vector(label, expected):
+    """OSV label-only severity (no CVSS vector) must map to the correct tier."""
+    vuln = {"severity": {"type": "CVSS_V3", "score": label}}
+    assert vuln_feed._suggest_severity(vuln, in_kev=False) == expected
+
+
+def test_keyboard_interrupt_not_swallowed_in_npm_fetch(tmp_path):
+    """KeyboardInterrupt raised inside a fetch must propagate, not be swallowed."""
+    def _raise(*_a, **_kw):
+        raise KeyboardInterrupt
+
+    with unittest.mock.patch.object(vuln_feed, "_https_fetch", side_effect=_raise):
+        with pytest.raises(KeyboardInterrupt):
+            vuln_feed.fetch_npm_freshness("mylib", "1.0.0", cache_dir=str(tmp_path))
+
+
+def test_keyboard_interrupt_not_swallowed_in_pypi_fetch(tmp_path):
+    """KeyboardInterrupt raised inside a fetch must propagate, not be swallowed."""
+    def _raise(*_a, **_kw):
+        raise KeyboardInterrupt
+
+    with unittest.mock.patch.object(vuln_feed, "_https_fetch", side_effect=_raise):
+        with pytest.raises(KeyboardInterrupt):
+            vuln_feed.fetch_pypi_freshness("mylib", "1.0.0", cache_dir=str(tmp_path))
+
+
 # ======================================================================
 # Torture room: adversarial inputs
 # ======================================================================


### PR DESCRIPTION
Two bugs: (1) When OSV returns severity as a label (CRITICAL) instead of a CVSS vector, _parse_cvss_score returns None and severity defaults to medium -- critical findings silently demoted. (2) All network fetch blocks use bare except Exception, swallowing SystemExit/KeyboardInterrupt. Added label-to-severity mapping fallback. Narrowed catches to (urllib.error.URLError, json.JSONDecodeError, OSError, ValueError).