### PR TITLE
feat(dead-anchors): repojacking/dangling-reference scanner (Skilljacking defense)

### DIFF
--- a/skills/repo-forensics/SKILL.md
+++ b/skills/repo-forensics/SKILL.md
@@ -181,6 +181,34 @@ JSON output for automation:
 | **oversize** | Files padded past the 10 MB scan cap (head+tail window scan) and whitespace-inflation padding that hides a payload after a long whitespace run | skill + full |
 | **bytecode** | Python `.pyc` bytecode: dangerous-call primitives (os.system/subprocess/exec), embedded URLs / credential paths, orphan bytecode, and **bytecode poisoning** (benign source + malicious `.pyc`) detected by a raw-marker source diff with no unmarshalling or execution (cross-version-safe). Disassembly is unmarshalled in an isolated subprocess so hostile bytecode cannot crash the scan, and is enrichment only — never load-bearing for the verdict | skill + full |
 | **archive** | Payloads hidden inside `.zip/.docx/.xlsx/.pptx/.jar/.whl/.tar.*` and other archives, including archives **renamed/forged to dodge extension gating** (detected by magic bytes + `is_zipfile`) and **scripts/executables smuggled inside an OOXML document** (HIGH structural flag). Members are read in memory (never written to disk) and run through the SAST / trifecta / secret / skill-threat detectors; bomb-, fan-out-, and tar-link-safe | skill + full |
+| **dead_anchors** | External-anchor **claimability**: repojackable GitHub owner/repo, phantom/removed npm & PyPI packages named in prose install commands, unregistered/expired domains (RDAP), and dangling free-tier cloud subdomains (Vercel/Railway/GitHub Pages/… via DNS + provider fingerprint). Closes the **Skilljacking** gap AIR's research says "tripped nothing at all" — the reference is dead and *claimable by an attacker* while the file content never changed. Network-touching but never-hard-fail: emits **only** on a confirmed-claimable anchor; live-and-owned and couldn't-check are silent. `--offline` degrades every anchor to silent. | skill + full |
+
+### Dead-anchor coverage and known scope (Skilljacking / repojacking)
+
+`dead_anchors` (motivated by AIR's *Skilljacking* research, plus the *Circus of
+Skills* free-tier-suffix study, Snyk's *ToxicSkills* IOCs, and the *SkillSieve*
+dataset — logged in `references/research_sources.md`) is precise, not total.
+Known limits, surfaced honestly rather than implied as covered:
+
+- **Rate-limit budget:** unauthenticated GitHub API is 60 req/hr/IP, so GH calls
+  are hard-capped (~20/scan, ~40 if `GITHUB_TOKEN` is set — read, never
+  required, never prompted) and a total per-scan probe ceiling (~50) plus a
+  wall-clock deadline bound the whole pass. Over-budget anchors degrade to
+  couldn't-check (silent, safe-by-design), never a false clear.
+- **RDAP ccTLD gaps:** `rdap.org`'s bootstrap covers gTLDs well; some ccTLDs
+  degrade to couldn't-check rather than a verdict.
+- **Multi-part-TLD heuristic:** a small vendored compound-TLD list (not a full
+  Public Suffix List, to stay zero-non-stdlib-dep), so some obscure ccTLD
+  domain reductions are imprecise.
+- **Fingerprint rot:** cloud-provider "deleted app" page strings change over
+  time; the fingerprint list is pack-driven (`data/rulepacks/dead_anchors.json`,
+  refreshed by the signed `refresh_threat_dbs.py` overlay) so it can be updated
+  without a code change. Netlify/Render/Surge deleted-app pages are generic 404
+  copy and are deliberately NOT fingerprinted (stay live-and-owned, never
+  guessed).
+- **Deferred:** verdict-decay / time-based recheck (a link live today can go
+  claimable later with zero file change) needs new persistent per-anchor state
+  and is a Phase-2 item, not built here.
 
 ### Bypass coverage and known scope (archive / oversize / bytecode)
 

--- a/skills/repo-forensics/data/rulepacks/dead_anchors.json
+++ b/skills/repo-forensics/data/rulepacks/dead_anchors.json
@@ -1,0 +1,183 @@
+{
+  "schema_version": "1.0",
+  "generated": "2026-07-04",
+  "pack": "dead_anchors",
+  "pack_version": 1,
+  "_comment": "Dead-Anchor / Repojacking scanner extraction rules + static lists. NOTE FOR MAINTAINERS: gen_rule_ids.py mints ids by AST-scraping module-level *_PATTERNS tables in scanner source; scan_dead_anchors.py has NONE (all its patterns live here), so 'DA' will emit ZERO rows in data/rule_ids.csv. That is expected, not a bug. The four extraction regexes (DA-GH-001/002, DA-PK-001, DA-DM-001) and the four data lists (DA-CL-001 cloud suffixes, DA-RW-001 reserved words, DA-SD-001 safe domains, DA-TLD-001 multi-part TLDs) are authored here directly (skill_threats.json convention). Provider fingerprints live under the top-level 'fingerprints' object (structured suffix->[{s,confidence}] data that no rule_loader type models); the scanner reads them directly. All lists are refreshed ONLY by the signed refresh_threat_dbs.py overlay; the scanner never writes this file.",
+  "rules": [
+    {
+      "id": "DA-GH-001",
+      "type": "regex",
+      "pattern": "(?:https?://)?github\\.com/([A-Za-z0-9][A-Za-z0-9._-]*)/([A-Za-z0-9][A-Za-z0-9._-]*)",
+      "title": "GitHub owner/repo URL anchor",
+      "severity": "info",
+      "confidence": 0.0,
+      "category": "dead-anchor-extract",
+      "explanation": "Extracts a github.com/<owner>/<repo> reference for claimability probing (repojacking). Reserved-word owners are filtered downstream (DA-RW-001).",
+      "examples": {
+        "match": [
+          "see github.com/torvalds/linux for source",
+          "clone https://github.com/hexiaochun/seedance2-api"
+        ],
+        "no_match": [
+          "see our github page for details",
+          "just visit github.com for docs"
+        ]
+      }
+    },
+    {
+      "id": "DA-GH-002",
+      "type": "regex",
+      "pattern": "github:([A-Za-z0-9][A-Za-z0-9._-]*)/([A-Za-z0-9][A-Za-z0-9._-]*)",
+      "title": "GitHub owner/repo shorthand anchor",
+      "severity": "info",
+      "confidence": 0.0,
+      "category": "dead-anchor-extract",
+      "explanation": "Extracts a github:<owner>/<repo> shorthand (the npx-skills install form AIR's seedance2-api case used) for claimability probing.",
+      "examples": {
+        "match": [
+          "install github:hexiaochun/seedance2-api",
+          "github:torvalds/linux"
+        ],
+        "no_match": [
+          "github: see the docs folder",
+          "on github the repo is public"
+        ]
+      }
+    },
+    {
+      "id": "DA-PK-001",
+      "type": "regex",
+      "pattern": "\\b(?:pip3?|npm|yarn|pnpm|gem|cargo|bundle)\\s+(?:install|add|i|get)\\s+(?:-\\S+\\s+)*([A-Za-z0-9@][A-Za-z0-9@/._-]*)",
+      "title": "Prose package-install anchor",
+      "severity": "info",
+      "confidence": 0.0,
+      "category": "dead-anchor-extract",
+      "explanation": "Extracts the package name from a prose install command (pip/npm/yarn/pnpm). Version specifiers and flags are stripped downstream; gem/cargo/bundle are extracted but not probed in P0.",
+      "examples": {
+        "match": [
+          "run pip install requests==2.31.0 first",
+          "npm install --save lodash@^4.17.0",
+          "pip3 install django"
+        ],
+        "no_match": [
+          "npx skills hexiaochun/seedance2-api",
+          "we install the software manually"
+        ]
+      }
+    },
+    {
+      "id": "DA-DM-001",
+      "type": "regex",
+      "pattern": "https?://([A-Za-z0-9][A-Za-z0-9.-]*\\.[A-Za-z][A-Za-z0-9.-]*)",
+      "flags": ["IGNORECASE"],
+      "title": "Bare-domain / cloud-subdomain URL anchor",
+      "severity": "info",
+      "confidence": 0.0,
+      "category": "dead-anchor-extract",
+      "explanation": "General URL host capture. Reduced to eTLD+1 for RDAP domain claimability, or routed to the cloud-subdomain probe when the host ends in a free-tier suffix (DA-CL-001). Safe-domain allowlist (DA-SD-001) is skipped.",
+      "examples": {
+        "match": [
+          "docs at https://myapp.vercel.app/home",
+          "see http://example.co.uk/page"
+        ],
+        "no_match": [
+          "email me at user@example.com",
+          "the path is /usr/local/bin"
+        ]
+      }
+    },
+    {
+      "id": "DA-CL-001",
+      "type": "keyword",
+      "values": [
+        "vercel.app", "railway.app", "netlify.app", "onrender.com", "fly.dev",
+        "herokuapp.com", "pages.dev", "web.app", "firebaseapp.com", "surge.sh",
+        "glitch.me", "replit.app", "github.io", "azurewebsites.net",
+        "pythonanywhere.com", "deno.dev", "workers.dev", "streamlit.app",
+        "ngrok-free.app"
+      ],
+      "title": "Free-tier cloud-hosting suffixes",
+      "severity": "info",
+      "confidence": 0.0,
+      "category": "dead-anchor-data",
+      "explanation": "Suffixes whose subdomains are trivially reclaimable once the app/project is deleted (DA-05/DA-09). First 6 named in AIR/Circus-of-Skills research; the rest are supplementary. Consumed via rule.values.",
+      "examples": {
+        "match": ["myapp.vercel.app", "user.github.io"],
+        "no_match": ["example.com", "docs.python.org"]
+      }
+    },
+    {
+      "id": "DA-RW-001",
+      "type": "keyword",
+      "values": [
+        "about", "apps", "blog", "collections", "contact", "dashboard",
+        "enterprise", "events", "explore", "features", "gist", "help", "home",
+        "issues", "join", "login", "logout", "marketplace", "mobile", "new",
+        "notifications", "organizations", "orgs", "plans", "pricing", "pulls",
+        "security", "sessions", "settings", "sponsors", "stars", "styleguide",
+        "topics", "trending", "watching"
+      ],
+      "title": "GitHub reserved-word owners (never probed)",
+      "severity": "info",
+      "confidence": 0.0,
+      "category": "dead-anchor-data",
+      "explanation": "First path segment values that are GitHub platform routes, not user/org names. A github.com/<reserved>/<x> reference is not a repojackable owner. Consumed via rule.values (exact-match against the owner, lowercased).",
+      "examples": {
+        "match": ["about", "marketplace"],
+        "no_match": ["torvalds", "hexiaochun"]
+      }
+    },
+    {
+      "id": "DA-SD-001",
+      "type": "keyword",
+      "values": [
+        "github.com", "githubusercontent.com", "npmjs.org", "registry.npmjs.org",
+        "pypi.org", "python.org", "nodejs.org", "docs.python.org",
+        "developer.mozilla.org", "stackoverflow.com", "wikipedia.org",
+        "anthropic.com", "claude.ai", "owasp.org", "w3.org", "ietf.org",
+        "rfc-editor.org"
+      ],
+      "title": "Safe-domain allowlist (never probed)",
+      "severity": "info",
+      "confidence": 0.0,
+      "category": "dead-anchor-data",
+      "explanation": "Stable platform domains that are never claimable and must not be RDAP-probed. Matched against the reduced eTLD+1. Consumed via rule.values.",
+      "examples": {
+        "match": ["github.com", "pypi.org"],
+        "no_match": ["evil-abandoned-domain.com", "myapp.vercel.app"]
+      }
+    },
+    {
+      "id": "DA-TLD-001",
+      "type": "keyword",
+      "values": [
+        "co.uk", "org.uk", "gov.uk", "ac.uk", "me.uk", "ltd.uk", "plc.uk",
+        "com.au", "net.au", "org.au", "edu.au", "gov.au",
+        "co.nz", "org.nz", "co.jp", "or.jp", "ne.jp", "ac.jp", "go.jp",
+        "co.in", "net.in", "org.in", "co.za", "org.za",
+        "com.br", "com.mx", "com.sg", "com.cn", "com.tr", "co.il", "com.hk"
+      ],
+      "title": "Multi-part TLDs for eTLD+1 reduction",
+      "severity": "info",
+      "confidence": 0.0,
+      "category": "dead-anchor-data",
+      "explanation": "Small vendored compound-TLD list (NOT a full Public Suffix List, to stay zero-non-stdlib-dep). Used to reduce a host to its registrable domain; obscure ccTLD reductions may be imprecise (documented). Consumed via rule.values.",
+      "examples": {
+        "match": ["example.co.uk", "shop.com.au"],
+        "no_match": ["example.com", "site.io"]
+      }
+    }
+  ],
+  "fingerprints": {
+    "_comment": "Provider dangling-slug fingerprints. ONLY entries marked \"strict\": true fire CONFIRMED-CLAIMABLE (DA-05), matched on non-alphanumeric token boundaries (not a loose substring anywhere in the body). Generic phrases that collide with live apps' own 404 copy were REMOVED after torture-room review: Cloudflare Pages 'project not found' and Railway 'Application not found' produced false CRITICALs against live, owned apps and are gone. Netlify/Render/Surge remain deliberately ABSENT for the same reason. A resolving host with no strict fingerprint stays LO (silent); only DNS NXDOMAIN is a stand-alone high-confidence claimable signal. Confidence feeds the Finding confidence.",
+    "github.io": [{"s": "There isn't a GitHub Pages site here", "confidence": 0.8, "strict": true}],
+    "herokuapp.com": [{"s": "There's nothing here, yet.", "confidence": 0.8, "strict": true}],
+    "web.app": [{"s": "Site Not Found", "confidence": 0.8, "strict": true}],
+    "firebaseapp.com": [{"s": "Site Not Found", "confidence": 0.8, "strict": true}],
+    "vercel.app": [
+      {"s": "DEPLOYMENT_NOT_FOUND", "confidence": 0.8, "strict": true},
+      {"s": "This deployment could not be found", "confidence": 0.8, "strict": true}
+    ]
+  }
+}

--- a/skills/repo-forensics/docs/plans/2026-07-04-001-feat-dead-anchors-scanner-plan.md
+++ b/skills/repo-forensics/docs/plans/2026-07-04-001-feat-dead-anchors-scanner-plan.md
@@ -1,0 +1,457 @@
+---
+title: "feat: Dead-Anchor / Repojacking Scanner (scan_dead_anchors.py)"
+date: 2026-07-04
+type: feat
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+origin: "DATA/SESSIONS/active/repo-forensics-skilljacking-2026-07-04/spec/DETECTION_SPEC.md (PERSONAL_OS repo; synthesized from findings/A_air_primary.md, B_secondary_vectors.md, C_academic_taxonomy.md, D_coverage_audit.md)"
+---
+
+# feat: Dead-Anchor / Repojacking Scanner
+
+## Summary
+
+Every skill/repo scanned today can reference a GitHub owner/repo, an npm/PyPI package, a bare domain, or a free-tier cloud subdomain that has since gone dead and become **claimable by an attacker** — the exact "Skilljacking" mechanic AIR's research post describes as tripping zero existing scanners, ours included. This plan adds `scan_dead_anchors.py`: an algorithmic (non-per-file) scanner that extracts every external anchor a skill points at, probes each for claimability via hardened HTTPS/DNS/RDAP calls through the already-audited `vuln_feed._https_fetch` plumbing, and emits a finding only when the anchor is definitively re-registerable — never on a live anchor, never on a network hiccup. It ships OSS, offline-degradable, and correlatable with repo-forensics' other 25 scanners, beating AIR's closed, methodology-silent SaaS on every axis the research surfaced.
+
+## Problem Frame
+
+AIR's Skilljacking research (and the corroborating academic/secondary-vector research in this session's `findings/`) identifies a structural gap: a skill's prose, manifest, or docs can point at an anchor (GitHub user, package name, domain, cloud subdomain) that was live when the skill was written but has since been deleted, renamed, or expired. The content itself never changes — no secret, no injected instruction, no malicious code — so every existing repo-forensics scanner (secrets, SAST, skill_threats, dependencies' typosquat/IOC matching) is silent, because none of them ask "is this reference *still owned by whoever the author meant*?" That is the gap this scanner closes.
+
+**Deferred note (verdict-decay):** an anchor confirmed live-and-owned at scan time can still decay to claimable weeks later with zero local file change (DA-07/DA-P2-5). Closing that gap needs new per-anchor persistent state that repo-forensics has no equivalent of today (the existing 24h caches in `vuln_feed`/`refresh_threat_dbs` are feed caches, not scan-result state). This plan builds the stateless P0/P1 core and defers the recheck/decay architecture to Phase 2 (see below) rather than building persistent state twice for DA-07 and its sibling DA-P2-5 (content-drift hashing).
+
+**Non-negotiable framing (Alex's explicit worry):** a network-touching scanner is the one shape in this codebase that can go wrong in three specific, user-visible ways — loops (retry storms, rate-limit hammering), races (concurrent scans corrupting shared cache state), and latency (a slow/hostile host hanging the whole scan). This plan treats freedom from all three as a hard acceptance gate, not an implementation detail: every probe is single-attempt with no retry, every host gets a per-scan circuit breaker, every cache write is atomic-and-lock-free, and the entire claimability pass runs under one wall-clock deadline. The scanner must feel weightless — `--offline` sub-second, a live scan bounded and provably terminating regardless of what the network does. See "Concurrency & Loop-Safety Contract" below, which the torture-room phase attacks directly (spec §10).
+
+## Requirements Traceability
+
+| Spec ID | Description | Status |
+|---|---|---|
+| DA-01 | GitHub user/org deleted/renamed → re-registerable | **In scope** (U2, U3) |
+| DA-02 | GitHub repo gone under a still-live user | **In scope** (U2, U3) |
+| DA-03 | Phantom/removed npm or PyPI package from a prose install command | **In scope** (U2, U3) |
+| DA-04 | Unregistered/lapsed domain via RDAP | **In scope** (U2, U3) |
+| DA-05 | Dangling cloud-hosting subdomain (DNS + fingerprint) | **In scope** (U2, U3) |
+| DA-09 | Free-tier-hosting-suffix structural flag (zero extra network cost) | **In scope** (U3) |
+| DA-10 | GitHub-owner trust signals (account age, repo count) — free off DA-01's response | **In scope** (U3), bundled per open question 7's resolution (see Decisions Log) |
+| DA-06 | Joint prose+code credential-leak correlation | **Deferred** (Follow-Up Work) |
+| DA-07 | Verdict-decay / time-based recheck | **Deferred** (Phase 2 — needs persistent state) |
+| DA-08 | Untrusted-external-instruction-fetch structural flag | **Deferred** (Follow-Up Work — scope boundary vs `scan_runtime_dynamism.py` needs a design pass) |
+| DA-11 | Reputation-inheritance abuse (star-count + recent-PR heuristic) | **Deferred** (Follow-Up Work — lower confidence, needs commit-date-vs-file-date heuristic) |
+| DA-P2-1..7 | Reasoning-layer attacks, LLM jury, sandboxed dynamic testing, WHOIS scoring, content-drift hashing, platform governance, runtime egress monitoring | **Deferred** (Phase 2 / out of scanner scope entirely for P2-6) |
+
+Already-covered categories (prompt injection, secrets, SAST, typosquatting, dependency confusion, provenance tampering, git tampering, etc.) are explicitly NOT rebuilt here — see spec §2 "Already covered" table; this scanner's job is exclusively anchor claimability.
+
+## Scope Boundaries
+
+**In scope**
+- `scripts/scan_dead_anchors.py`: standalone algorithmic scanner, `SCANNER_NAME = "dead_anchors"`.
+- Anchor extraction (GitHub URL/shorthand, prose package-install commands, bare domains, cloud subdomains) from `SKILL.md`/`AGENTS.md`/etc. (reusing `_shared_patterns.SEED_FILES`) and MCP manifest files (`.mcp.json`).
+- Claimability probes for the 5 P0 anchor types (DA-01 through DA-05) via a thin wrapper over `vuln_feed._https_fetch`.
+- DA-09 (free-tier-suffix flag) and DA-10 (GitHub-owner trust signals), both zero-marginal-cost extensions of the P0 probes.
+- `data/rulepacks/dead_anchors.json`: pack-driven extraction regexes, cloud-suffix list, safe-domain allowlist, GitHub reserved-word exclusions.
+- A small bundled multi-part-TLD data file for eTLD+1 domain reduction (documented as an imprecise heuristic, not a full PSL).
+- Registration into `SKILL.md`, `run_forensics.sh`, `auto_scan.py`, `gen_rule_ids.py`, `tests/test_non_breaking_contract.py`.
+- Full test suite: positive/negative/never-hard-fail, all network monkeypatched, plus benign-corpus additions.
+
+**Deferred to Follow-Up Work**
+- **DA-06** — joint prose+code credential-leak correlation. Needs a new cross-scanner correlation shape (SKILL.md prose near a credential pattern vs. the actual code sink); distinct project, not part of anchor claimability.
+- **DA-07** — verdict-decay / time-based recheck. Needs new per-anchor persistent scan-result state (does not exist in repo-forensics today); biggest single architecture decision, explicitly punted (see Decisions Log).
+- **DA-08** — untrusted-external-instruction-fetch structural flag. Needs an explicit scope line against `scan_runtime_dynamism.py` (code-level fetch-then-execute) before it can be built without double-firing on the same "fetch external content" pattern from the prose angle.
+- **DA-11** — reputation-inheritance abuse. Lower-confidence heuristic (commit-date-vs-file-date), needs its own validation pass against real repos before it's worth shipping.
+- **All P2 items** (DA-P2-1 through DA-P2-7) — reasoning-layer/LLM-jury/sandboxed-dynamic-testing/WHOIS-scoring/content-drift-hashing/platform-governance/runtime-egress-monitoring. Different scanner shapes, heavier infra, or not a scanner concern at all (P2-6). See Phase 2 / Future.
+
+**Out of scope entirely**
+- Any change to existing scanners' detection logic (secrets, SAST, skill_threats, dependencies, provenance, etc.) — this is purely additive.
+- WHOIS/registrar-reputation scoring beyond the RDAP registered/unregistered signal (DA-P2-4).
+- Any code that requires a paid API key for baseline operation (`GITHUB_TOKEN` stays optional-never-required, per Alex's standing "no API keys for graceful UX" rule).
+
+## High-Level Technical Design
+
+Pipeline (single pass per scan):
+
+```
+repo/skill files (SEED_FILES + .mcp.json)
+        │
+        ▼
+┌─────────────────────────┐
+│ U1: anchor extraction    │  pack-driven regexes (dead_anchors.json)
+│  - GitHub URL/shorthand  │  + safe-domain allowlist + reserved-word skip
+│  - prose package-install │  + cloud-suffix list + mini multi-part-TLD file
+│  - bare domain           │
+│  - cloud subdomain       │
+└────────────┬─────────────┘
+             │ list[Anchor(type, value, ...)]
+             ▼
+┌──────────────────────────────────────────────────────────┐
+│ U2: claimability probe layer (thin wrapper over            │
+│     vuln_feed._https_fetch — HTTPS-only, size-capped,      │
+│     timeout-bounded, atomic 0o600 cache, --offline bypass) │
+│                                                              │
+│   for each anchor (GH call budget ~15-20/scan enforced):    │
+│     try fetch → urllib.error.HTTPError caught FIRST         │
+│       .code == 404            → CC (signal, not failure)    │
+│       .code in {403,429,5xx}  → NC (silent)                 │
+│     generic URLError/timeout  → NC (silent)                 │
+│     200                       → LO (silent)                 │
+└────────────┬─────────────────────────────────────────────┘
+             │ verdict per anchor: CC | LO | NC
+             ▼
+┌─────────────────────────┐
+│ U3: scan_dead_anchors.py │  3-tier classify → Finding only on CC
+│  scan_repo(repo_path)    │  DA-09 (free-tier suffix) + DA-10 (owner trust)
+│  -> list[Finding]        │  bundled in, zero extra network cost
+└────────────┬─────────────┘
+             │
+             ▼
+   core.output_findings() / correlation engine (cross-scanner, unchanged)
+```
+
+The never-hard-fail contract is the load-bearing design constraint: `LO` and `NC` are BOTH silent (no Finding), and only `CC` (confirmed-claimable) emits. This mirrors `scan_provenance.py`'s three-tier signal partition exactly, renamed for this domain (see Key Technical Decisions, KTD-3).
+
+## Key Technical Decisions
+
+**KTD-1 — Standalone algorithmic scanner, not a per-file walk.**
+`scan_repo(repo_path, ignore_patterns=None) -> list[Finding]` iterates *extracted anchors*, not `core.walk_repo`. Mirrors `scan_provenance.py`'s shape exactly (`ignore_patterns` accepted for uniform registration but unused, since this is an artifact/anchor-level check). Registered as a standalone scanner in `tests/test_non_breaking_contract.py`'s `EXPECTED_BASE_SCANNER_NAMES` set, same bucket as `"provenance"` and `"splitstream"`.
+
+**KTD-2 — All network calls go through one wrapper over `vuln_feed._https_fetch`.**
+No fourth hand-rolled `urlopen` call site. The wrapper enforces HTTPS-only, a fixed User-Agent, `NETWORK_TIMEOUT_SEC`, and a response byte cap, matching every existing network-touching scanner. DNS resolution for cloud subdomains (`socket.gethostbyname`) is the one exception — it has no HTTP equivalent and is called directly, wrapped in the same try/except discipline (`socket.gaierror` → NC, never a crash).
+
+**KTD-3 — HTTPError-first branching inverts the exact anti-pattern in `vuln_feed.fetch_npm_freshness`/`fetch_pypi_freshness`.**
+Those two functions (`vuln_feed.py` lines ~594 and ~690-694) catch the generic `urllib.error.URLError` first, which silently collapses a real, informative 404 into the same `return None` as a genuine network failure. `urllib.error.HTTPError` subclasses `URLError`, so this scanner's fetch wrapper catches `HTTPError` FIRST and branches on `.code`: `404` is signal (CC), `403`/`429`/`5xx` is `NC`, anything else unexpected is `NC`. The generic `URLError`/timeout/`socket.error` catch comes second and always yields `NC`. This ordering is the single most important correctness property in the whole scanner — get it backwards and every CC downgrades to a silent NC, and the scanner detects nothing.
+
+**KTD-4 — Three-tier signal partition (CC/LO/NC), with LO and NC BOTH silent.**
+Directly ports `scan_provenance.py`'s `_TAMPERING_SIGNALS`/`_ABSENT_SIGNALS`/`_AMBIGUOUS_SIGNALS` precedence pattern into this domain's vocabulary: CONFIRMED-CLAIMABLE emits, LIVE-AND-OWNED is the normal state of the world (silent, same posture as provenance's "unsigned"), COULDN'T-CHECK is silent (never an INFO-level "unchecked" per-anchor line — that trains users to ignore output, the exact trap `scan_provenance.py`'s own docstring names). One optional scanner-level summary line at the end of `--format text` output ("N anchors probed, M skipped") is allowed for operator visibility but is never a `Finding` and never affects exit code.
+
+**KTD-5 — GitHub API call budget capped at 15-20/scan; `GITHUB_TOKEN` optional-never-required.**
+Unauthenticated GitHub API is 60 req/hr/IP. A repo with many GitHub anchors, or repeated scans in a session, exhausts this fast. Rather than requiring an env var (which reintroduces the API-key friction Alex has explicitly banned for Total Recall enrichment and elsewhere), the scanner hard-caps GH calls per scan run and silently NC's the rest (unprobed = unchecked = safe, per KTD-4). If `GITHUB_TOKEN` is present in the environment it is used opportunistically to raise the budget to the authenticated ceiling, but its absence never degrades UX beyond "some anchors go unchecked this run" — no prompt, no warning nag.
+
+**KTD-6 — Extraction rules and static lists are pack-driven; probe/classification logic is code-baked.**
+Per `rule_loader.py`'s intended split: pure pattern matching (GitHub URL regex, package-install regex, cloud-suffix list, safe-domain allowlist, GitHub reserved-word list) lives in `data/rulepacks/dead_anchors.json` as `type: "regex"`/`"keyword"` rules with `examples.match`/`examples.no_match` self-tests. The claimability/liveness verdict logic (network probes, HTTPError branching, 3-tier classification) is algorithmic and stays in `scan_dead_anchors.py` with `rule_id=""` on emitted Findings — same convention as `scan_provenance.py`'s one Finding type.
+
+**KTD-7 — Domain eTLD+1 reduction uses a small bundled multi-part-TLD data file, not a full Public Suffix List.**
+Zero-non-stdlib-dep constraint rules out a PSL library. A static data file (`data/dead_anchors_multi_tld.txt` or embedded in the rulepack) covering common compound TLDs (`co.uk`, `com.au`, `github.io`, etc.) is vendored and the imprecision is documented in-code and in SKILL.md — some eTLD+1 extractions will be wrong for obscure ccTLDs, which degrades to either an over-broad or under-broad domain check, never a crash.
+
+**KTD-8 — Zero non-stdlib dependencies.**
+Everything (regex extraction, `urllib`/`socket` network calls, RDAP JSON parsing) uses stdlib + `forensics_core`/`vuln_feed`/`rule_loader` only, consistent with every other scanner in the tool.
+
+**KTD-9 — RDAP via `rdap.org` bootstrap for domain claimability, not raw WHOIS.**
+`https://rdap.org/domain/{domain}` resolves to the correct registry RDAP server and returns JSON over HTTPS — no port-43 socket code, no WHOIS text parsing. A 404 is CC (unregistered/expired), 200 is LO (registered, with a secondary imminent-expiry check against the `events[].expiration` array for a lower-severity flag), anything else is NC. ccTLD coverage gaps are a known limitation (see Decisions Log).
+
+**KTD-10 — Cloud-subdomain fingerprints, GitHub reserved words, cloud-suffix list, and safe-domain allowlist are pack-driven data, not hardcoded Python.**
+This lets `refresh_threat_dbs.py`'s existing signed-feed cadence refresh the fingerprint strings when providers redesign their error pages, without a code change — the exact rot risk the spec's open question 3 flags. The pack is read-only at scan time; the scanner never writes `data/rulepacks/dead_anchors.json` itself (only `refresh_threat_dbs.py`'s existing signed overlay pipeline does, per its established cadence — no new cron, no new refresh loop is introduced by this scanner).
+
+**KTD-11 — Per-provider circuit breaker: one strike and the whole host is done for the scan.**
+The first 429/403 response from a given host (GitHub is the realistic case, given its 60/hr unauthenticated ceiling) trips a per-scan, per-host breaker; every subsequent anchor that would hit that host is short-circuited straight to NC with zero further calls. This is a stronger, simpler guarantee than the GH numeric call budget alone (KTD-5) — the budget caps volume, the breaker stops entirely on the first sign of throttling, and the two compose (whichever trips first wins). No backoff, no sleep-and-retry: a tripped breaker never un-trips within the same scan.
+
+**KTD-12 — Single-attempt probes, no retries, ever.** A failed probe (of any NC-classified kind) is final for that anchor within that scan. There is no code path anywhere in `dead_anchors_probe.py` that re-issues the same request. This is what makes the loop-safety guarantee structural rather than "we tested it and it seemed fine" — there is simply no retry loop to misbehave.
+
+**KTD-13 — Global network deadline + total probe ceiling, composing with the per-provider GH budget.**
+Beyond GitHub's own 15-20 call cap (KTD-5), the whole claimability pass is bounded two ways simultaneously: (a) a total-probe ceiling across ALL anchor types (~50/scan) so a skill with hundreds of npm/PyPI/domain references can't turn into hundreds of sequential HTTP calls, and (b) one shared wall-clock deadline for the entire pass (mirroring `scan_provenance.py`'s `_Deadline`/`TOTAL_BUDGET_SEC` pattern exactly), so a slow or deliberately-hanging host can never stall the scan — once the deadline expires, every remaining anchor is skipped straight to NC. Both caps are enforced BEFORE a request is issued (an anchor over budget never even calls `_https_fetch`), not after a slow response comes back.
+
+**KTD-14 — Atomic, lock-free 24h result cache; no self-trigger.**
+Anchor verdicts are cached for 24h using the identical write-to-temp-in-the-same-dir + `os.replace()` + `0o600` pattern `vuln_feed._atomic_write` already implements — reused directly, not reimplemented. No file locks (no `flock`, no lockfile) are used anywhere: two concurrent scans of the same repo (a manual full scan racing the `auto_scan.py` PostToolUse hook) can each read a possibly-stale-but-never-torn cache and each may write their own atomic replace; the last writer wins and no reader ever observes partial JSON, because `os.replace()` is a single atomic syscall on POSIX. A missing, truncated, or malformed cache entry degrades to a cache-miss (re-probe subject to the usual budget/deadline/breaker, or NC if those are exhausted) — never a crash, per the same tolerant-read discipline `vuln_feed._load_cache` already uses. Separately: this scanner performs read-only GET/DNS/RDAP calls exclusively — it never installs, clones, or mutates git state, so it structurally cannot trip `auto_scan.py`'s PostToolUse hook (which keys on install/clone commands). Scanner → hook → scanner is not just avoided, it is impossible given the hook's trigger surface.
+
+## Concurrency & Loop-Safety Contract
+
+This is a first-class acceptance gate (spec §10), not an implementation footnote — the torture-room phase (U5) attacks it directly, and the six scenarios below are non-negotiable Verification Contract items.
+
+| Property | Guarantee | Where it's enforced |
+|---|---|---|
+| **No retries** | Single attempt per anchor; a failed probe is final for that scan | KTD-12; no retry loop exists in `dead_anchors_probe.py` |
+| **Per-provider circuit breaker** | First 429/403 from a host trips a per-scan breaker; every later anchor to that host → instant NC, zero further calls | KTD-11 |
+| **No self-trigger** | Read-only GET/DNS/RDAP only; never installs/clones/mutates git → cannot trip `auto_scan.py`'s PostToolUse hook | KTD-14 |
+| **Bounded iteration** | Anchor set is finite, extracted once, deduped before any probe fires; no recursion over network responses | U1 (dedup at extraction) + KTD-13 (probe ceiling) |
+| **Atomic cache, no locks** | `vuln_feed._atomic_write`'s temp+`os.replace()`+`0o600` pattern, reused not reimplemented; zero `flock`/lockfile → zero deadlock surface | KTD-14 |
+| **Tolerant reads** | Missing/partial/malformed cache entry → cache-miss or NC, never a crash | KTD-14 |
+| **No shared mutable state across scanners** | GH budget counter, circuit-breaker state, and deadline are all local to one `scan_repo()` invocation; the only cross-invocation artifact is the atomic on-disk cache | U2/U3 |
+| **Feed pack is read-only at scan time** | `data/rulepacks/dead_anchors.json` is refreshed only by the existing signed `refresh_threat_dbs.py` pipeline; the scanner never writes it; no new cron/loop | KTD-10 |
+| **Dedup before probing** | Unique `(anchor_type, target)` set computed in U1; N references to the same anchor cost exactly 1 probe | U1 |
+| **Hard caps** | GitHub ≤ ~15-20 calls/scan (KTD-5), total probe ceiling ≤ ~50/scan across all types (KTD-13); overflow → silent NC | KTD-5, KTD-13 |
+| **Global network deadline** | One wall-clock budget for the entire claimability pass; expiry stops further probes, remaining anchors → NC, scan completes promptly | KTD-13 |
+| **24h result cache** | Re-scanning the same repo within 24h reuses cached per-anchor verdicts; no re-probe within the TTL | KTD-14 |
+| **Parallel-friendly** | Runs as one more `throttled_run` job in `run_forensics.sh`, alongside the other 25 scanners; does not serialize the pipeline | U4 |
+| **`--offline` = instant + silent** | Zero network attempted, every anchor → NC immediately, zero findings, sub-second | U2/U3 (`offline` param short-circuits before any socket call) |
+
+**Distinction from Phase-2 verdict-decay (important, do not conflate):** the 24h result cache above is a pure latency/rate-limit optimization — it caches "what did we last observe for this exact anchor" the same way `vuln_feed`'s existing freshness caches do, and a cache-miss just re-probes normally. DA-07/DA-P2-5 (deferred to Phase 2) is a different problem: proactively detecting that a PREVIOUSLY-live anchor has since gone claimable with zero local file change, which requires comparing verdicts ACROSS scans over time (a decay-detection ledger), not just avoiding redundant probes WITHIN a short TTL. Building the 24h cache now does not build DA-07's state architecture; they are related but distinct, and conflating them would either under-scope this plan's caching need or over-scope it into Phase 2's territory.
+
+## Implementation Units
+
+### U1. Anchor extraction module + rulepack
+
+**Goal:** Given a repo path, extract every candidate anchor (GitHub owner/repo, prose package-install target, bare domain, cloud subdomain) with zero network calls, applying the safe-domain allowlist and GitHub-reserved-word exclusions so noise is filtered before any probe is even considered.
+
+**Requirements:** DA-01, DA-02, DA-03, DA-04, DA-05 (extraction half only — no probing here), DA-09 (cloud-suffix membership is computed here, consumed in U3).
+
+**Dependencies:** None (first unit).
+
+**Files:**
+- `scripts/dead_anchors_extract.py` (new) — extraction functions, pure stdlib, imports `rule_loader`.
+- `data/rulepacks/dead_anchors.json` (new) — extraction regexes/keyword lists per KTD-6.
+- `data/dead_anchors_multi_tld.txt` (new) — bundled compound-TLD list per KTD-7 (or embed as a rulepack keyword-type rule if that fits the schema more cleanly than a bespoke file format; decide at implementation time based on which the `rule_loader` self-test harness covers more naturally).
+- `tests/test_dead_anchors_extract.py` (new).
+
+**Approach:**
+1. Build `data/rulepacks/dead_anchors.json` mirroring `skill_threats.json`'s schema exactly: `schema_version: "1.0"`, `pack: "dead_anchors"`, `pack_version: 1`, one rule per extraction pattern from spec §3 (`DA-GH-001` GitHub URL, `DA-GH-002` `github:` shorthand, `DA-PK-001` package-install prose, `DA-DM-001` bare domain, `DA-CL-001` cloud-subdomain suffix match), plus keyword-type rules for the GitHub reserved-word exclusion list and the safe-domain allowlist (spec §3 tables, verbatim).
+2. `dead_anchors_extract.py` loads the pack via `rule_loader.load_pack("dead_anchors")`, exposes `extract_anchors(file_paths) -> list[Anchor]` where `Anchor` is a small dataclass/namedtuple: `(type, raw_value, owner=None, repo=None, ecosystem=None, file=None, line=None)`.
+3. Read anchors from `_shared_patterns.SEED_FILES` (`SKILL.md`, `AGENTS.md`, `CLAUDE.md`, etc.) plus `.mcp.json`/`mcp.json` if present, matching `scan_agent_skills.py`'s file-discovery convention.
+4. Apply the safe-domain allowlist and GitHub reserved-word list as extraction-time filters (never probed at all), and de-duplicate anchors (same owner/repo/package/domain referenced twice in one skill = one probe).
+5. For package-install extraction: strip version specifiers/flags per spec §3's regex, infer ecosystem from the verb (`pip*`→PyPI, `npm`/`yarn`/`pnpm`→npm; `gem`/`cargo`/`bundle`/`go get` extracted but NOT probed in P0 — tag them `ecosystem=None` so U2 skips them cleanly).
+6. For domain extraction: reduce to eTLD+1 using the bundled multi-part-TLD list; skip if the reduced domain is in the safe allowlist.
+
+**Patterns to follow:** `rule_loader.load_pack()` / `CompiledPack.all_rules` iteration (see `_shared_patterns.py`'s `_values_for()` helper for the pack-with-fallback pattern — though this module has no legacy hardcoded fallback to preserve, so it can load directly and treat a missing/invalid pack as "extraction pack unavailable, scanner has nothing to probe this run" rather than crashing). Rule IDs `DA-GH-001`, `DA-GH-002`, `DA-PK-001`, `DA-DM-001`, `DA-CL-001` per spec §6.
+
+**Test scenarios:**
+- `github.com/torvalds/linux` in SKILL.md → one GitHub anchor `(torvalds, linux)`.
+- `github:hexiaochun/seedance2-api` → same anchor shape via shorthand pattern.
+- `github.com/about` → NO anchor (reserved word `about` excluded).
+- `npx skills hexiaochun/seedance2-api` → package-install extraction does NOT double-fire as a GitHub anchor (this string is the shorthand-pattern's own worked example from spec §6, not a `pip/npm install` verb match).
+- `pip install requests==2.31.0` → PyPI anchor `requests`, version specifier stripped.
+- `npm install --save lodash@^4.17.0` → npm anchor `lodash`, flag and specifier stripped.
+- `see our github page for details` → NO anchor (no owner/repo captured, per spec §6 self-test example).
+- `https://github.com/x/y` and a second, identical reference elsewhere in the same file → exactly ONE anchor after de-dup.
+- `https://vercel.app` bare (no subdomain) → excluded structurally (suffix match requires a subdomain segment).
+- `myapp.vercel.app` → cloud anchor, suffix `vercel.app`, flagged `is_free_tier=True` for DA-09.
+- `https://docs.python.org/3/library/os.html` → NO anchor (safe-domain allowlist).
+- `example.co.uk` → eTLD+1 reduces to `example.co.uk` (compound TLD), not `co.uk`.
+- Rulepack self-test: every rule's `examples.match`/`examples.no_match` passes under `rule_loader.self_test_pack()`.
+
+**Verification:** `pytest tests/test_dead_anchors_extract.py -v` green; `python3 scripts/rule_loader.py dead_anchors` reports 0 failed self-tests.
+
+---
+
+### U2. Network claimability layer
+
+**Goal:** For each extracted anchor, produce a CC/LO/NC verdict via hardened, budget-capped network probes, with zero possibility of a hard crash or hang regardless of what the network returns.
+
+**Requirements:** DA-01, DA-02, DA-03, DA-04, DA-05 (the probe half), the GH call-budget decision from KTD-5, DA-10's data collection (the raw GitHub user response is captured here for U3 to interpret).
+
+**Dependencies:** U1 (consumes `Anchor` objects; can be developed against a hand-built anchor list in its own tests without waiting on U1's extraction regex correctness).
+
+**Files:**
+- `scripts/dead_anchors_probe.py` (new) — `probe_github_user`, `probe_github_repo`, `probe_npm`, `probe_pypi`, `probe_domain_rdap`, `probe_cloud_subdomain`, each returning a small result object `(verdict, raw_response_or_None)`; plus the shared `_ProbeBudget`/`_Deadline`/`_CircuitBreaker` state objects and the atomic result-cache read/write helpers.
+- `tests/test_dead_anchors_probe.py` (new).
+
+**Approach:**
+1. One shared fetch wrapper `_probe_https(url, max_bytes) -> (verdict, parsed_json_or_None)` that calls `vuln_feed._https_fetch` and implements the HTTPError-first branch from KTD-3: `except urllib.error.HTTPError as e:` checked BEFORE `except urllib.error.URLError`. `e.code == 404` → `("CC", None)`; `e.code in (403, 429)` or `500 <= e.code < 600` → `("NC", None)`; any other code → `("NC", None)`. Then `except (urllib.error.URLError, OSError, TimeoutError):` → `("NC", None)`. On success, `("LO", parsed_json)`. This is a SINGLE attempt (KTD-12) — no loop, no `for attempt in range(...)`, nothing that could retry.
+2. **Circuit breaker (KTD-11):** a small per-scan `_CircuitBreaker` object keyed by host (`api.github.com`, `registry.npmjs.org`, `pypi.org`, `rdap.org`, or the specific cloud subdomain's registrable suffix) tracks "tripped" booleans. Immediately after `_probe_https` classifies a response as NC via a 429 or 403 status specifically (not a generic timeout/5xx — those don't imply throttling), the breaker trips for that host. Every subsequent probe function checks `breaker.is_tripped(host)` BEFORE calling `_probe_https` and returns `("NC", None)` instantly if tripped, without issuing a request. A tripped breaker never resets within the scan (no timer, no retry-after honoring — simplicity over cleverness, since honoring `Retry-After` would reintroduce a wait/backoff shape the loop-safety contract explicitly forbids).
+3. **Budget + total probe ceiling + global deadline (KTD-5, KTD-13):** `probe_github_user`/`probe_github_repo` consume one unit of a shared `_ProbeBudget` GH-specific counter (~15-20/scan); ALL probe functions additionally consume one unit of a shared TOTAL ceiling (~50/scan) regardless of type. A single `_Deadline` object (same shape as `scan_provenance.py`'s `_Deadline`/`TOTAL_BUDGET_SEC`: `remaining()`/`expired()`, constructed once per `scan_repo()` call) is threaded through every probe call; each probe function checks `deadline.expired()` FIRST, before the GH/total budget check, before the circuit breaker check, before issuing any request — cheapest checks first, network last. Any of the three exhausted → instant `("NC", None)`, zero request issued. The per-request `NETWORK_TIMEOUT_SEC` from `vuln_feed` bounds any individual call that IS issued, so the deadline is a backstop, not the only timeout.
+4. **24h atomic result cache (KTD-14):** before issuing any probe, check a cache keyed on `(anchor_type, normalized_target)` at `~/.cache/repo-forensics/dead-anchors/{sha256-of-key}.json` (or a single consolidated cache file, decide at implementation time based on which reads more naturally through `vuln_feed._load_cache`'s existing helper — reuse that function directly rather than writing a second cache-age-check implementation). A cache hit within 24h returns the cached verdict without any network call, budget consumption, or deadline check (a cache hit costs nothing). A cache miss, or a cache read that raises `OSError`/`json.JSONDecodeError`/schema-mismatch, falls through to a normal probe (tolerant read — never a crash). Writes use `vuln_feed._atomic_write` (temp file in the same directory + `os.replace()` + `0o600`) exactly as-is, imported and called directly — not reimplemented. No file lock of any kind.
+5. `probe_github_user(owner, ctx)`: GET `https://api.github.com/users/{owner}`, `ctx` bundling the budget/breaker/deadline/cache objects. On `LO`, the raw JSON (`created_at`, `public_repos`, `bio`) is returned for DA-10.
+6. `probe_github_repo(owner, repo, ctx)`: only called by U3 if the owner probe returned `LO` (spec §4 — repo-gone-under-live-user is a weaker, conditional signal). Same shape.
+7. `probe_npm(name, ctx)` / `probe_pypi(name, ctx)`: GET `registry.npmjs.org/{name}` / `pypi.org/pypi/{name}/json`. No GH-specific budget, but still subject to the total ceiling, deadline, and cache.
+8. `probe_domain_rdap(domain, ctx)`: GET `https://rdap.org/domain/{domain}`. On `LO`, additionally inspect the `events` array for a past-dated `expiration` and surface it as a secondary flag (imminent-expiry, lower severity) rather than a distinct verdict tier.
+9. `probe_cloud_subdomain(subdomain, suffix, ctx)`: first `socket.gethostbyname(subdomain)` wrapped in `try/except socket.gaierror: return ("CC", None)` (NXDOMAIN = confirmed claimable) `except OSError: return ("NC", None)`; on successful resolution, GET `https://{subdomain}` and match the response body against the pack-driven provider-fingerprint list (HIGH-confidence fingerprints only fire `CC`; MEDIUM-confidence/no-match → `LO` per spec §4's explicit "do not guess" instruction for Netlify/Render/Surge).
+10. All probe functions accept an `offline: bool` param; when `True`, return `("NC", None)` immediately before any budget/breaker/deadline/cache check even runs — `--offline` must be the cheapest, fastest path in the whole module (sub-second, per spec §10's "lightweight/seamless" requirement), not just "skip the socket call after doing everything else."
+11. Dedup happens once, upstream, in U1 — U2's functions are never called twice for the same `(anchor_type, target)` within one scan; this unit does not re-implement dedup, it relies on receiving an already-unique anchor list.
+
+**Patterns to follow:** `vuln_feed._https_fetch(url, max_bytes)` for every HTTPS call (no direct `urlopen`). `vuln_feed._atomic_write` / `vuln_feed._load_cache` reused directly for the 24h result cache (do not reimplement atomic-write-with-temp-and-replace a second time in this module). `scan_provenance.py`'s `_Deadline`/`TOTAL_BUDGET_SEC` pattern for both the wall-clock deadline and, in spirit, the numeric budget counters (a small class with `remaining()`/`expired()`).
+
+**Test scenarios (all network monkeypatched via `scanner.urllib.request.urlopen` / `scanner.socket.gethostbyname`, per `tests/test_scan_provenance.py:26-45` convention):**
+- Canned 404 on GH user → `("CC", None)`.
+- Canned 404 on npm → `("CC", None)`; canned 404 on PyPI → `("CC", None)`.
+- Canned 404 on RDAP domain → `("CC", None)`.
+- `socket.gaierror` on cloud subdomain DNS → `("CC", None)`.
+- 200 body containing "DEPLOYMENT_NOT_FOUND" for a `vercel.app` subdomain (DNS resolves but app deleted) → `("CC", None)` via fingerprint match.
+- 200 body containing "project not found" for `pages.dev` → `("CC", None)` (Cloudflare Pages, MEDIUM-confidence fingerprint, still fires per spec table).
+- 200 body of generic unrelated content on `netlify.app` → `("LO", ...)` (generic 404 copy explicitly NOT trusted as a fingerprint per spec §4).
+- Canned 200 (registered/found) on every endpoint type → `("LO", parsed)`, never a Finding downstream.
+- Canned 403 → `("NC", None)`; canned 429 → `("NC", None)`; canned 500 → `("NC", None)`; `socket.timeout`/`TimeoutError` → `("NC", None)`. Assert NO exception propagates in any of these cases (never-hard-fail).
+- GH budget exhausted (counter at 0) → `probe_github_user` returns `("NC", None)` WITHOUT calling `urlopen` at all (assert the monkeypatched `urlopen` was not invoked).
+- `offline=True` → every probe returns `("NC", None)` with zero network attempts, for all 6 functions.
+- RDAP 200 with a past `expiration` event → verdict `LO` but the imminent-expiry secondary flag is set.
+- **Circuit breaker trips on first 429**: monkeypatch GH user probe #1 to raise `HTTPError(429)`; assert probe #2 for a DIFFERENT owner on the same host (`api.github.com`) returns `("NC", None)` WITHOUT any call to the monkeypatched `urlopen` (breaker short-circuits before the request). Assert a probe to a DIFFERENT host (e.g. `registry.npmjs.org`) in the same scan is NOT affected by the GitHub breaker (per-host, not global).
+- **No retry, ever**: monkeypatch `urlopen` with a call-count assertion; feed it a 429 once; confirm the SAME anchor is never probed a second time within the scan (single attempt, KTD-12) — the breaker prevents OTHER anchors from probing that host, but this test specifically confirms the ORIGINAL anchor itself isn't retried.
+- **Total probe ceiling**: construct 60 unique anchors across mixed types (not all GitHub, to isolate the total-ceiling behavior from the GH-specific budget); assert no more than ~50 probes are actually attempted (assert via call-count on the monkeypatched network functions) and the remainder resolve to `("NC", None)`.
+- **Global deadline**: monkeypatch every probe's underlying call to sleep past a artificially-shortened test deadline (monkeypatch the deadline constant/budget like `scan_provenance.py`'s tests monkeypatch `TOTAL_BUDGET_SEC`); assert the scan returns promptly (bounded wall-clock in the test, not an actual multi-second sleep) with all not-yet-attempted anchors as `("NC", None)`, and zero exceptions.
+- **24h cache hit avoids network entirely**: pre-populate the cache file with a valid, fresh (< 24h) verdict for a given anchor; call the probe; assert `urlopen`/`gethostbyname` was NEVER invoked and the cached verdict is returned as-is.
+- **24h cache miss (expired) re-probes normally**: pre-populate the cache with a verdict timestamped > 24h old; assert the probe DOES call the network and the cache is refreshed via `vuln_feed._atomic_write` afterward.
+- **Malformed/partial cache tolerated**: pre-populate the cache file with truncated JSON / wrong schema / a directory instead of a file at that path; assert the probe falls through to a normal network probe with NO exception raised (tolerant read, KTD-14).
+- **Concurrent-write safety (simulated)**: two sequential calls to the cache-write helper for the SAME anchor key (simulating two racing scans) both complete without raising, and the final on-disk file is valid, complete JSON (never a torn/partial write) — verified by asserting `os.replace` (not a raw `open().write()`) is the mechanism used, per `vuln_feed._atomic_write`'s existing implementation.
+
+**Verification:** `pytest tests/test_dead_anchors_probe.py -v` green, including an explicit assertion (via a monkeypatched `urlopen` call-counter) that no test ever performs a real network call.
+
+---
+
+### U3. Scanner orchestration (`scan_dead_anchors.py`)
+
+**Goal:** Wire extraction (U1) and probing (U2) into the actual `scripts/scan_dead_anchors.py` entry point: 3-tier classification, `Finding` emission per spec §2's severity/confidence table, DA-09/DA-10 bundled in, argparse shape, and the optional end-of-scan summary line.
+
+**Requirements:** DA-01 through DA-05 (end-to-end), DA-09, DA-10.
+
+**Dependencies:** U1, U2.
+
+**Files:**
+- `scripts/scan_dead_anchors.py` (new).
+- `tests/test_scan_dead_anchors.py` (new).
+
+**Approach:**
+1. `SCANNER_NAME = "dead_anchors"`.
+2. `scan_repo(repo_path, ignore_patterns=None, offline=False) -> list[Finding]`: constructs ONE shared probe context per call (`_Deadline` for the global wall-clock budget, `_ProbeBudget` for the GH cap + total ceiling, `_CircuitBreaker` for per-host trip state, and the cache-dir path for the 24h result cache — all local to this invocation, never module-level mutable globals, per the Concurrency & Loop-Safety Contract's "no shared mutable state across scanners" line), calls `dead_anchors_extract.extract_anchors(...)` to get the deduped anchor list, then for each anchor dispatches to the matching U2 probe (GH owner → conditional GH repo per spec §4's "only if owner LO" gate; npm/PyPI; RDAP domain; cloud subdomain) passing the shared context, classifies CC/LO/NC, and emits a `Finding` ONLY on CC.
+3. Per-anchor-type severity/confidence from spec §2's P0 table: DA-01 critical/0.90, DA-02 medium/0.55, DA-03 critical/0.90, DA-04 high/0.85 (critical if the domain is itself an install/fetch target rather than a passing mention — a secondary structural check on surrounding prose verb, best-effort), DA-05 critical/0.80 (fingerprint) or 0.90 (NXDOMAIN).
+4. DA-09: for every cloud-subdomain anchor (regardless of CC/LO/NC verdict on liveness), if its suffix is in the free-tier list, this is an independent structural signal — decide at implementation time whether it fires as its own low-severity Finding on EVERY free-tier reference (matching spec's "regardless of current liveness" framing) or is folded into the DA-05 Finding's description as an aggravating factor when DA-05 already fired. Given the never-train-users-to-ignore-alarms principle (KTD-4), default to the latter (fold into DA-05, do not double-count) unless spec review during implementation decides the standalone low-severity signal has independent value; document the choice in `decisions.md`.
+5. DA-10: when a GH owner probe returns `LO`, inspect the captured `created_at`/`public_repos`/`bio` fields; if account age < 1 year AND `public_repos` is very low AND `bio` is empty, attach this as supplementary context on the eventual DA-02 Finding for that owner's repo (if one fires) rather than emitting its own standalone Finding — DA-10 has no CC/LO/NC verdict of its own, it's an enrichment of DA-01/DA-02's verdict. (Resolves spec open question 7: bundled here for zero marginal cost, not split into its own scanner, because it produces no independent finding — only enriches an existing one.)
+6. Build `argparse.ArgumentParser` locally in `main()` (repo_path, `--format`, `--offline`) exactly mirroring `scan_dependencies.py`'s pattern — do NOT invent `--no-network`, do NOT rely on `core.parse_common_args` (which has no offline flag).
+7. Emit the optional end-of-scan summary line ("N anchors probed, M skipped: rate-limited/offline") to stderr/status output only in `--format text`, never as a `Finding`, never counted toward `output_findings`' severity tally.
+8. `main()` follows `scan_provenance.py`'s shape: `core.emit_status(...)`, `core.load_ignore_patterns(repo_path)` (accepted, unused), `scan_repo(...)`, `core.output_findings(all_findings, args.format, SCANNER_NAME)`.
+
+**Patterns to follow:** `scan_provenance.py`'s `scan_repo()`/`main()` structure end-to-end (this is the closest existing analog: standalone, algorithmic, silent-by-default). `Finding(scanner=SCANNER_NAME, severity=..., title=..., description=..., file=<seed file path where the anchor was found>, line=<line if extractable, else 0>, snippet=<the raw anchor reference, truncated>, category="dead-anchor", rule_id="")`.
+
+**Test scenarios:**
+- Full pipeline, GH user 404 (monkeypatched) → exactly one CRITICAL Finding, `category="dead-anchor"`, title mentions the owner name.
+- Full pipeline, GH owner LO + GH repo 404 → exactly one MEDIUM Finding (DA-02), confidence 0.55.
+- Full pipeline, GH owner LO + GH repo LO (both live) → zero Findings.
+- Full pipeline, npm package 404 → one CRITICAL Finding; PyPI 404 → one CRITICAL Finding.
+- Full pipeline, RDAP domain 404 → one HIGH Finding; RDAP 200 with imminent expiration → zero Findings today (LO stays silent; expiry-aware severity is documented as a future refinement, not built as a distinct verdict in P0 — confirm this against spec §4's wording during implementation and adjust if spec intends an actual lower-severity Finding for imminent expiry, in which case implement it as HIGH-but-lower-confidence, not a new verdict tier).
+- Full pipeline, cloud subdomain NXDOMAIN → one CRITICAL Finding (confidence 0.90); fingerprint-match 200 → one CRITICAL Finding (confidence 0.80).
+- Full pipeline, every probe returns NC (simulated 403 across the board) → zero Findings, zero exceptions, process exits cleanly.
+- `--offline` flag → zero network calls attempted (assert via monkeypatched `urlopen` call count == 0), zero Findings, clean exit.
+- GH budget cap: a repo with 25 distinct GitHub-owner anchors → at most ~15-20 probed (assert via call counter), the rest silently skipped, zero crash.
+- `--format json` output round-trips through `Finding.to_dict()` with all expected keys present.
+- `--format summary` produces the `"dead_anchors: N findings (...)"` line.
+
+**Verification:** `pytest tests/test_scan_dead_anchors.py -v` green. Manual smoke: `python3 scripts/scan_dead_anchors.py <fixture-repo> --format text` and `--offline` both exit 0/1/2 appropriately with no traceback.
+
+---
+
+### U4. Registration (wire into the aggregation pipeline)
+
+**Goal:** Make `dead_anchors` a first-class scanner in every place repo-forensics enumerates scanners, so it runs in both skill-scan and full-scan modes, participates in the PostToolUse auto-scan hook, and doesn't silently fall out of the non-breaking-contract test.
+
+**Requirements:** Registration mechanics per spec §1 (4 points) and §6 (rule-id abbreviation).
+
+**Dependencies:** U3 (the script must exist and run before wiring it into orchestration).
+
+**Files:**
+- `SKILL.md` — new row in the Scanners table, mode `skill + full`.
+- `scripts/run_forensics.sh` — add `throttled_run run_scanner "dead_anchors" "scan_dead_anchors.py" &` to BOTH the `--skill-scan` block and the full-scan block (confirmed both blocks already list `provenance` last; add `dead_anchors` alongside it in each).
+- `scripts/auto_scan.py` — add `'scan_dead_anchors.py'` to the `targeted_scanners` list in `run_targeted_scan` (confirmed list currently has 16 entries ending in `scan_bytecode.py`).
+- `scripts/gen_rule_ids.py` — add `"scan_dead_anchors.py": "DA"` to `_SCANNER_ABBREV`.
+- `tests/test_non_breaking_contract.py` — add `"dead_anchors"` to `EXPECTED_BASE_SCANNER_NAMES`.
+
+**Approach:**
+1. SKILL.md row, matching the existing table's column format: `| **dead_anchors** | GitHub/npm/PyPI/domain/cloud-subdomain claimability (repojacking, phantom packages, expired domains, dangling cloud slugs) | skill + full |`.
+2. `run_forensics.sh`: two one-line additions, verified against the actual current line numbers at implementation time (spec's cited ~354-368/~377-405 are approximate; grep for the existing `"provenance"` line in each block and insert `dead_anchors` immediately after it, consistent with how `provenance` itself was appended last in both blocks).
+3. `auto_scan.py`: one-line addition to the `targeted_scanners` list.
+4. `gen_rule_ids.py`: add the abbreviation entry. **Important caveat to verify during implementation:** `gen_rule_ids.py` mints ids by AST-parsing each scanner's module-level `*_PATTERNS`/`*_KEYWORDS` table literals (see `collect_tables()`/`_is_pattern_table()`) — it does NOT read JSON rulepacks. Since `dead_anchors`'s extraction rules live entirely in `data/rulepacks/dead_anchors.json` (KTD-6) with ids already assigned directly in that JSON (matching `skill_threats.json`'s convention, where rule ids are authored in the JSON, not generated by this tool), adding `"scan_dead_anchors.py": "DA"` to `_SCANNER_ABBREV` is registration-for-completeness and will emit ZERO rows for `dead_anchors` in `data/rule_ids.csv` (no hardcoded pattern tables exist in `scan_dead_anchors.py` to scrape) — this is expected, not a bug. Document this in the rulepack's own header comment so a future maintainer doesn't go looking for missing CSV rows.
+5. `test_non_breaking_contract.py`: add to the set (not a numbered list — verify against current line, spec's "~77" is approximate).
+
+**Patterns to follow:** Exact existing surrounding syntax in each file (bash `&` job pattern, Python list literal, set literal, markdown table row).
+
+**Test scenarios:**
+- `pytest tests/test_non_breaking_contract.py -v` — `EXPECTED_BASE_SCANNER_COUNT` increments by 1 and all existing assertions still pass against a live `run_forensics.sh --format json` run.
+- `run_forensics.sh <fixture> --skill-scan --format json` — `scanners` array includes a `dead_anchors` entry.
+- `run_forensics.sh <fixture> --format json` (full mode) — same.
+- `auto_scan.run_targeted_scan(<fixture>)` — includes `dead_anchors` findings (or empty list) without raising.
+- `python3 scripts/gen_rule_ids.py --print` — runs without error; confirm zero `DA` rows are expected and documented (not silently wrong).
+
+**Verification:** Full `pytest` run green (existing + new tests). `run_forensics.sh` manual run against a clean fixture repo shows `dead_anchors` in scanner output with `finding_count: 0`.
+
+---
+
+### U5. Tests + benign corpus additions
+
+**Goal:** Complete the test matrix from spec §7 — positive (teeth) tests, negative tests, never-hard-fail tests, and new benign-corpus entries — so the scanner is provably both loud on real dead anchors and silent on clean ones.
+
+**Requirements:** Spec §7 items 1-6 (test corpus plan), the SkillSieve security-gate step (manual pre-step, not a code unit), the ToxicSkills negative-control cross-check.
+
+**Dependencies:** U1, U2, U3 (needs the full pipeline to exist).
+
+**Files:**
+- `tests/corpus/benign/dead_anchors_live_repo.md` or an addition to an existing benign SKILL.md fixture (new) — references repo-forensics' own stable GitHub org/repo (owner-controlled lifecycle, avoids third-party CI flakiness per spec §7 item 3a).
+- `tests/corpus/benign/*` additions for a live npm package (`lodash`), live PyPI package (`requests`), `github:` shorthand to the same stable repo, and either a live cloud-subdomain reference or a mocked LO-branch fixture (spec §7 item 3d — mock if no stable public one is safe to depend on in CI).
+- `tests/corpus/budgets.json` — updated with the `dead_anchors` scanner's expected zero-finding budget on the benign corpus.
+- `tests/test_dead_anchors_extract.py`, `tests/test_dead_anchors_probe.py`, `tests/test_scan_dead_anchors.py` (already created in U1-U3; this unit is the pass where the FULL spec §7 matrix is confirmed present across them, plus the benign-corpus regression gate).
+
+**Approach:**
+1. **Manual pre-step (not code, do NOT skip, do NOT automate away):** before extracting any SkillSieve labeled-skill fixtures into `tests/corpus/`, clone `github.com/xiaohou521/skillsieve` into an isolated temp dir and run a full repo-forensics scan on the clone. Review findings. Only after that review is clean (or reviewed-and-accepted) do specific labeled skill folders get copied into `tests/corpus/`. This is Alex's non-negotiable repo-forensics-first rule applied to the test fixture itself, and it gates U5, not something U5's code does for you.
+2. Add the ToxicSkills 8 live-malicious IOC URLs (e.g. `clawhub.ai/zaycv/clawhud`) as domain/URL entries submitted to the `ioc_manager.py` signed feed process (this is a feed-content change, not a `scripts/` code change — see Test Corpus & Security Gate section below for the exact mechanics) and additionally use them as negative-control fixtures: a test that confirms `scan_dead_anchors.py` does not double-fire or conflict with `ioc_manager`'s existing IOC flag on the same anchor.
+3. New benign-corpus entries per spec §7 item 3: (a) repo-forensics' own live GitHub org/repo reference, (b) `lodash`/`requests` live-package references, (c) `github:` shorthand to the same stable repo, (d) one live cloud-subdomain reference OR a mocked-LO fixture.
+4. Positive (teeth) tests, mirroring the existing `test_teeth_planted_*` naming pattern used elsewhere in the suite: for each of the 4 P0 anchor types, monkeypatch to return a canned 404/NXDOMAIN/fingerprint body, assert the correct severity+category fires.
+5. Negative tests: canned 200/registered responses for all 4 types → zero findings. Canned 403/429/5xx/timeout for all 4 types → zero findings AND no crash (same shape as `tests/test_run_scanner_fail_loud.py`, though that file tests `auto_scan.run_scanner`'s subprocess-failure wrapper, not this scanner's internal try/except — both layers get exercised: this scanner must never raise internally, AND if it somehow did, `run_scanner`'s existing fail-loud wrapper is the backstop, not a reason to skip internal hardening).
+6. All network calls in the test suite monkeypatched (`scanner.urllib.request.urlopen`, `scanner.socket.gethostbyname`) — confirmed zero real HTTP/DNS calls via an assertion helper, per `tests/test_scan_provenance.py:26-45`'s convention.
+
+**Patterns to follow:** `tests/test_benign_corpus.py`'s budget-file convention (`tests/corpus/budgets.json`) for the zero-finding regression gate; `tests/corpus/benign/` directory's existing flat-file structure (SKILL.md, package.json, etc. sit directly in that directory today — follow the same layout, don't invent subdirectories unless the existing convention already has one for scanner-specific fixtures).
+
+**Test scenarios:** (superset of U1-U3's per-unit scenarios, consolidated here for the corpus-level check)
+- Running the FULL benign corpus (including the new dead-anchor-relevant fixtures) through `scan_dead_anchors.py` in offline mode → zero findings, budget respected.
+- Running the full benign corpus WITH live network mocked to "everything resolves/200s" → zero findings.
+- ToxicSkills IOC URL present in a test fixture → `ioc_manager` fires its existing IOC-match finding; `dead_anchors` either stays silent (if the IOC domain still resolves, since IOC-badness ≠ claimability) or fires independently (if the IOC domain happens to ALSO be unregistered) — assert no crash, no duplicate-finding conflict, and that the two scanners' findings are clearly distinguishable by `scanner` field and `category`.
+
+**Verification:** `pytest tests/ -v` full suite green, including `tests/test_benign_corpus.py`'s budget gate with `dead_anchors` now in scope. `python3 -m pytest tests/test_dead_anchors_extract.py tests/test_dead_anchors_probe.py tests/test_scan_dead_anchors.py -v` all pass in isolation.
+
+---
+
+### U6. SKILL.md docs + threat-source logging
+
+**Goal:** Document the new scanner's coverage and known limitations in SKILL.md, and log AIR/Skilljacking as a research source per repo-forensics' existing convention of citing the security research that motivated each scanner.
+
+**Requirements:** Documentation completeness; no detection-logic requirement.
+
+**Dependencies:** U1-U5 (docs describe the shipped behavior, written last).
+
+**Files:**
+- `SKILL.md` — scanners table row (already added in U4) plus, if SKILL.md has a "bypass coverage and known scope" or equivalent prose section (it does, for archive/oversize/bytecode per the file's existing structure), a short paragraph on dead-anchor coverage limits: RDAP ccTLD gaps, fingerprint-string rot risk, multi-part-TLD imprecision, the GH call-budget cap.
+- `SYSTEM/references/research_sources.md`-equivalent within repo-forensics (check whether such a file exists; if repo-forensics has no dedicated research-sources log, add a brief "Research sources" note near the scanner's SKILL.md row instead, or check for a `CHANGELOG.md`/`docs/` convention already in use for this purpose and follow it — do not invent a new file/location without checking existing convention first).
+
+**Approach:**
+1. Add the known-scope paragraph to SKILL.md immediately following the scanners table, in the same voice as the existing archive/oversize/bytecode "Bypass coverage and known scope" section.
+2. Cite AIR's Skilljacking research post and the Circus of Skills / ToxicSkills / SkillSieve sources from `findings/A_air_primary.md` and `findings/B_secondary_vectors.md` as the motivating research, matching however repo-forensics currently attributes its other CSA/Trail-of-Bits-motivated scanners in SKILL.md prose (grep existing scanner sections for "per X's audit" / "(CSA / Trail of Bits, ...)" style citations and mirror that exact convention rather than inventing new phrasing).
+
+**Patterns to follow:** Existing SKILL.md prose style for citing external security research (the archive/oversize/bytecode section explicitly names "CSA / Trail of Bits, June 2026" as the motivating audit).
+
+**Test scenarios:** N/A (documentation unit; verification is a read-through, not a test).
+
+**Verification:** SKILL.md renders correctly (no broken markdown table), scanners table row count matches `EXPECTED_BASE_SCANNER_COUNT` from U4's test.
+
+## Test Corpus & Security Gate
+
+- **SkillSieve fixture safety gate (mandatory, blocking, manual):** before any labeled skill folder from `github.com/xiaohou521/skillsieve` is copied into `tests/corpus/`, clone it into an isolated temp directory and run a full `repo-forensics` scan against the clone. Review the findings. This is Alex's standing repo-forensics-first rule for any external code being evaluated for use, applied here to the test fixture data itself — do not skip this step because "it's just test data."
+- **ToxicSkills 8 live-malicious IOC URLs** (Snyk-sourced, e.g. `clawhub.ai/zaycv/clawhud`, `clawhub.ai/Aslaep123/polymarket-traiding-bot`): add to the `ioc_manager.py` signed-feed content (this is a feed-authoring change through whatever process Alex uses to publish `iocs/latest.json` to the `repo-forensics` GitHub repo `ioc_manager.py` pulls from — NOT a direct edit to a file inside `scripts/` or `data/` in this repo, since the IOC feed is remote and signature-verified). Additionally use these 8 URLs as negative-control test fixtures per U5.
+- **All test-suite network calls are monkeypatched.** No test in `tests/test_dead_anchors_*.py` ever performs a real HTTP request or DNS lookup — every scenario replaces `urllib.request.urlopen` and `socket.gethostbyname` at the module level the scanner imports them under, per the existing `tests/test_scan_provenance.py` convention.
+
+## Verification Contract
+
+- `pytest tests/` — full suite green, including the 3 new test files (`test_dead_anchors_extract.py`, `test_dead_anchors_probe.py`, `test_scan_dead_anchors.py`) and the updated `test_non_breaking_contract.py` (scanner count +1, `dead_anchors` present in every scan mode's JSON output).
+- `tests/test_benign_corpus.py`'s budget gate stays green with `dead_anchors` in scope — zero findings on the full benign corpus (including the new dead-anchor-specific benign fixtures from U5).
+- `python3 scripts/scan_dead_anchors.py <any-repo> --offline` emits ZERO findings and exits 0, with zero network calls attempted (manually confirm via a network-blocking sandbox or an strace/lsof spot-check, not just the mocked unit tests).
+- `python3 scripts/rule_loader.py dead_anchors` reports 0 failed self-tests (every rule's `examples.match`/`examples.no_match` passes).
+- `python3 scripts/gen_rule_ids.py --print` runs cleanly and regenerates `data/rule_ids.csv` without error (0 new `DA` rows expected and documented, per U4's caveat — this is NOT a failure).
+- `run_forensics.sh <fixture> --format json` (both skill-scan and full modes) includes a `dead_anchors` scanner entry with a valid `exit_code`/`finding_count`/`findings` shape matching `REQUIRED_SCANNER_ENTRY_KEYS`.
+
+**Torture-room gate (spec §10 — non-negotiable, blocks merge if any fails):**
+1. **Two concurrent scans over the same repo** (e.g. two `subprocess.Popen` invocations of `scan_dead_anchors.py` against the same target, or two in-process threads calling `scan_repo()` against the same cache dir) → no torn cache file (the on-disk JSON is always fully valid, never half-written), no crash in either process, and identical verdicts returned by both (same anchors, same network responses in the test double → same classification regardless of write-order race).
+2. **Simulated 429 on the first GitHub call** → the circuit breaker trips (KTD-11); assert zero further calls to `api.github.com` for the remainder of that scan, and assert no retry was attempted on the original call.
+3. **Network timeout on every single probe** (monkeypatch every network function to raise `TimeoutError`/`socket.timeout`) → the scan finishes within the configured deadline (bounded, not hanging), emits zero findings, and exits cleanly (exit code 0, no traceback).
+4. **Duplicate anchors ×50** (the same `(owner, repo)` or same domain referenced 50 times across the seed files) → exactly ONE probe is issued for that anchor (dedup at extraction, U1), not 50.
+5. **`--offline` opens zero sockets** — assert via a monkeypatch that raises `AssertionError` (or records a call) if `urllib.request.urlopen` or `socket.gethostbyname` is invoked at all during an `--offline` run; assert zero findings and a sub-second wall-clock (no artificial sleep anywhere on the offline path).
+6. **Malformed/partial cache file on disk** (truncated JSON, wrong top-level type, a directory where a file is expected) → tolerated; the scan falls through to a normal probe (or NC if budget/deadline is also exhausted) with no exception surfacing to the caller.
+
+## Decisions Log
+
+### Design Decisions
+- Standalone algorithmic scanner (KTD-1), not a per-file walk — anchors are extracted once per scan, not per file.
+- HTTPError-first branching (KTD-3) is the scanner's single most load-bearing correctness property; every probe function's tests must explicitly exercise the 404-vs-generic-failure distinction.
+- DA-10 bundled into DA-01/DA-02's Finding as enrichment, not a standalone Finding (resolves spec open question 7) — it has no independent CC/LO/NC verdict.
+- GH call budget capped, `GITHUB_TOKEN` optional-never-required (resolves spec open question 1) — chosen over mandatory-token because Alex has explicitly banned API-key friction elsewhere (Total Recall enrichment) and an unprobed anchor degrading to silent NC is safe by KTD-4's design.
+
+### Tradeoffs
+- Capping GH calls at ~15-20/scan means a large repo with many GitHub anchors will have some anchors silently unchecked (NC) rather than exhaustively probed. This trades completeness for staying within the unauthenticated rate limit without requiring a token — acceptable because NC is safe-by-design (never a false-clear, never a crash), just incomplete.
+- The bundled multi-part-TLD list (KTD-7) is deliberately not a full PSL — some ccTLD domain reductions will be imprecise. Documented, not silently wrong.
+- DA-09 (free-tier-suffix flag) folding into DA-05's Finding rather than firing standalone (see U3 step 4) trades a small amount of independent signal value for avoiding double-counting/alert fatigue; flagged as a decision to revisit if implementation review finds real value in the standalone signal.
+
+### Open Questions (carried from spec §9, still unresolved — flag for a follow-up decision, not blocking this build)
+- **RDAP ccTLD gaps** — `rdap.org`'s bootstrap covers gTLDs well but ccTLD support varies; some domain checks will degrade to NC purely due to RDAP coverage, not actual liveness. Spot-check a handful of common ccTLDs during U2 implementation before treating RDAP as fully reliable; if a ccTLD gap turns out to be large, consider surfacing it in the end-of-scan summary line.
+- **Fingerprint rot cadence** — cloud-provider error-page copy will change over time (KTD-10 makes the list pack-driven specifically so `refresh_threat_dbs.py` can update it, but no automatic freshness-check exists yet for "is this fingerprint still accurate" — that would require periodically re-fetching a known-dead reference URL per provider, which is a possible Phase 2 addition, not built here).
+- **PSL imprecision** — accepted per KTD-7, documented, not resolved (a full PSL would require either a bundled large static file or a network fetch of the real Mozilla PSL, both rejected for now to keep the dependency/size footprint small).
+- **DA-08 scope boundary vs `scan_runtime_dynamism.py`** — still needs an explicit design pass (not attempted in this build) to ensure the two scanners don't eventually double-fire on the same "fetch external content" pattern from the prose vs. code angle when DA-08 is picked up as Follow-Up Work.
+
+## Phase 2 / Future
+
+- **DA-07 verdict-decay / time-based recheck + DA-P2-5 content-drift hash-pin-and-diff** — both need new per-repo, per-anchor persistent state across scans, which repo-forensics has no equivalent of today. Bundle these into ONE architecture decision when picked up (don't build persistent state twice): likely a new `~/.cache/repo-forensics/dead-anchors-state/{repo-hash}.json` ledger keyed on anchor identity, with a scheduled re-scan trigger (cron-style, outside this scanner's own invocation) that diffs today's verdict/content-hash against the ledger and surfaces NEWLY-claimable or NEWLY-drifted anchors as a distinct "regression" Finding type.
+- **DA-06 joint prose+code credential-leak correlation** — a genuinely different scanner shape (cross-references SKILL.md prose against actual code sinks), not an anchor-claimability extension; picked up as its own plan when prioritized.
+- **DA-08 untrusted-external-instruction-fetch structural flag** — needs the `scan_runtime_dynamism.py` scope-boundary design pass noted above before implementation.
+- **DA-11 reputation-inheritance abuse** — needs a validation pass against real repos to calibrate the commit-date-vs-file-date heuristic before it's worth the false-positive risk of shipping.
+- **DA-P2-1/2/3 (reasoning-layer attacks, LLM jury, sandboxed dynamic execution)** — explicitly out of repo-forensics' zero-non-stdlib-dep, offline-first posture; would be a different product/architecture entirely, not an extension of this scanner.
+- **DA-P2-4 (WHOIS-based domain-age/registrar-reputation/TLD-risk scoring)** — a refinement layer on top of P0's RDAP check, not needed for the core CC/LO/NC verdict; revisit if RDAP-only proves insufficiently precise in practice.
+- **DA-P2-6 (registry/platform governance recommendations)** — not a scanner concern at all; no code to write, ever, in this codebase.
+- **DA-P2-7 (runtime egress monitoring against a declared-domain allowlist)** — needs a runtime hook, a fundamentally different scanner shape (`auto_scan.py`-style continuous monitoring, not a point-in-time `scan_dead_anchors.py` invocation).

--- a/skills/repo-forensics/references/research_sources.md
+++ b/skills/repo-forensics/references/research_sources.md
@@ -77,6 +77,25 @@ This skill's AI agent threat detection capabilities are informed by published se
 - **Resource**: OWASP formal taxonomy of MCP vulnerability classes
 - **Coverage in this skill**: MCP01 (Prompt Injection), MCP05 (Tool Poisoning), MCP06 (Insecure Tool Design), MCP09 (Supply Chain)
 
+## Dead-Anchor / Repojacking Research (Skilljacking)
+
+### AIR Security: Skilljacking
+- **Finding**: A skill's prose/manifest/docs can reference an external anchor (a GitHub owner/repo, an npm/PyPI package named in an install command, a domain, or a free-tier cloud subdomain) that was live when the skill was authored but has since been deleted, renamed, or expired — leaving it **claimable by an attacker** with zero change to the file content.
+- **Key insight**: Because the content never changes (no injected instruction, no secret, no malicious code), every existing content-scanner "tripped nothing at all" — the gap is *anchor claimability*, not content.
+- **Attack vectors**: (1) deleted/renamed GitHub user/org → re-registerable username; (2) phantom/removed npm/PyPI package → squattable name; (3) unregistered/expired domain; (4) dangling free-tier cloud subdomain (Vercel/Railway/etc.) whose app was deleted.
+- **Impact on this skill**: Motivated `scan_dead_anchors.py` (DA-01..DA-05, DA-09 free-tier flag, DA-10 owner-trust signals). Claimability is confirmed via read-only GitHub API / npm & PyPI registry / RDAP / DNS+fingerprint probes; a finding fires only on a confirmed-claimable anchor, never on a live one or a network hiccup.
+
+### Circus of Skills: free-tier hosting suffixes
+- **Finding**: 98 skills / ~1.6M installs referenced apps on trivially-reclaimable free-tier suffixes (`vercel.app`, `github.io`, …).
+- **Impact on this skill**: The free-tier-suffix flag (DA-09) and the cloud-subdomain suffix list in `data/rulepacks/dead_anchors.json`.
+
+### Snyk ToxicSkills — 8 live-malicious IOC URLs (negative control)
+- **Use**: The ToxicSkills malicious IOC URLs (e.g. `clawhub.ai/...`) belong in `ioc_manager.py`'s signed IOC feed, and serve as negative-control fixtures confirming `scan_dead_anchors.py` does not double-fire or conflict with the existing IOC flag on the same anchor (IOC-badness ≠ claimability).
+
+### SkillSieve dataset (test corpus, security-gated)
+- **Resource**: `github.com/xiaohou521/skillsieve` — 49,592 skills + 400 labeled, permissively licensed; the most usable public dataset for benign/malicious fixtures.
+- **Handling**: Extraction of any labeled folder into `tests/corpus/` is gated behind a mandatory repo-forensics-first scan of an isolated clone (Alex's standing external-code rule applied to the test data itself). Not automated; see `tests/corpus/DEAD_ANCHORS_CORPUS.md`.
+
 ## Note on Originality
 
 Detection patterns in this skill are original work, informed by the threat intelligence published in the above research. No code was copied from any of the referenced tools or research. Regular expressions, detection logic, severity scoring, and correlation rules were all written from scratch based on documented attack techniques and indicators of compromise.

--- a/skills/repo-forensics/scripts/auto_scan.py
+++ b/skills/repo-forensics/scripts/auto_scan.py
@@ -336,6 +336,7 @@ def run_targeted_scan(repo_path):
         'scan_provenance.py',
         'scan_archive.py',
         'scan_bytecode.py',
+        'scan_dead_anchors.py',
     ]
 
     from concurrent.futures import ThreadPoolExecutor, as_completed

--- a/skills/repo-forensics/scripts/dead_anchors_extract.py
+++ b/skills/repo-forensics/scripts/dead_anchors_extract.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""
+dead_anchors_extract.py - Anchor extraction for the dead-anchor / repojacking
+scanner (U1).
+
+Given a repo path, pulls every EXTERNAL anchor a skill/repo points at, with ZERO
+network calls:
+  - GitHub owner/repo (URL form DA-GH-001, `github:` shorthand DA-GH-002),
+    reserved-word owners (DA-RW-001) filtered out.
+  - Prose package-install targets (DA-PK-001); pip->PyPI, npm/yarn/pnpm->npm;
+    gem/cargo/bundle are extracted but tagged ecosystem=None (no P0 probe).
+  - Bare domains (DA-DM-001) reduced to eTLD+1 via the vendored multi-part-TLD
+    list (DA-TLD-001); safe-domain allowlist (DA-SD-001) skipped.
+  - Free-tier cloud subdomains (DA-CL-001 suffix membership).
+
+Everything data-driven lives in data/rulepacks/dead_anchors.json (feed-updatable,
+read-only at scan time). Anchors are DE-DUPLICATED before return so N references
+to the same target cost exactly one probe downstream (loop-safety, spec §10).
+
+Never raises on a scan target: a missing/invalid pack => "nothing to probe this
+run" (empty list), a malformed seed file => skipped, never a crash.
+
+Created by Alex Greenshpun
+"""
+
+import os
+import re
+import sys
+import stat
+from collections import namedtuple
+
+_O_NONBLOCK = getattr(os, "O_NONBLOCK", 0)
+
+_SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import rule_loader
+
+try:
+    from _shared_patterns import SEED_FILES as _SEED_FILES
+except Exception:  # pragma: no cover - fallback if shared pack unavailable
+    _SEED_FILES = {
+        'SKILL.md', 'SOUL.md', 'HEARTBEAT.md', 'ROUTINE.md', 'AGENTS.md',
+        'BOOT.md', 'BOOTSTRAP.md', 'CLAUDE.md', 'IDENTITY.md', 'USER.md',
+    }
+
+# Additional non-seed manifest files worth scanning for anchors.
+_EXTRA_FILES = {".mcp.json", "mcp.json", "README.md", "readme.md"}
+
+# Directories we never descend into (heavy / vendored / vcs).
+_SKIP_DIRS = {
+    ".git", "node_modules", ".venv", "venv", "__pycache__", "dist", "build",
+    ".tox", ".mypy_cache", ".pytest_cache", "site-packages",
+}
+
+# Bounds (loop-safety / lightweight): never read an unbounded tree.
+_MAX_FILES = 200
+_MAX_FILE_BYTES = 1_000_000
+# Hard cap on distinct extracted anchors so a maximally-adversarial (but
+# within-file-count/size-bound) repo cannot drive extraction / the downstream
+# dispatch loop into multi-minute / multi-GB territory (python-redos F3).
+_MAX_ANCHORS = 5000
+
+
+def normalize_npm_name(name):
+    """npm package identity is case-insensitive and lowercase; an @scope is kept
+    but lowercased too. Used for BOTH the existence probe and the dedup key so
+    'npm install React' and 'react' resolve to one live package, not a phantom."""
+    return (name or "").strip().lower()
+
+
+def normalize_pypi_name(name):
+    """PEP 503 canonical form: lowercase and collapse any run of -, _ or . to a
+    single -. 'My_Package', 'my-package', 'my.package' are one distribution."""
+    return re.sub(r"[-_.]+", "-", (name or "").strip()).lower()
+
+# Verbs near a domain that promote DA-04 from HIGH to CRITICAL (the domain is an
+# active fetch/install target, not a passing mention). Best-effort, per spec §2.
+_FETCH_VERB_RE = re.compile(
+    r"(?i)\b(curl|wget|fetch|download|source|install|clone|git\s+clone|pip\s+install|"
+    r"npm\s+install|require|import\s+from)\b"
+)
+
+# One immutable anchor record. `raw` is the original reference (for the snippet);
+# `target` is the normalized probe key; `is_free_tier` flags DA-09.
+Anchor = namedtuple(
+    "Anchor",
+    ["type", "target", "owner", "repo", "ecosystem", "suffix",
+     "is_free_tier", "file", "line", "raw", "fetch_context"],
+)
+
+
+def _rule_by_id(pack, rule_id):
+    if pack is None:
+        return None
+    try:
+        rules = pack.all_rules
+    except Exception:
+        return None
+    for r in rules:
+        if getattr(r, "id", None) == rule_id:
+            return r
+    return None
+
+
+def _keyword_values(rule):
+    """Values of a keyword rule, or an empty set for anything else. A pack that
+    has been tampered/corrupted so this id is authored as a NON-keyword type
+    (rule.values is then None) must degrade to 'no data', never crash on
+    set(None) (python-redos F2 / error-soundness never-hard-fail)."""
+    if rule is None or getattr(rule, "type", None) != "keyword":
+        return set()
+    vals = getattr(rule, "values", None)
+    if not vals:
+        return set()
+    try:
+        return set(vals)
+    except TypeError:
+        return set()
+
+
+class _Extractor:
+    """Compiled pack view. Built once per scan; holds the four extraction
+    regexes and the four static lists. A missing pack degrades to a no-op
+    extractor (every extract_* returns nothing) rather than crashing."""
+
+    def __init__(self, pack=None, base_dir=None):
+        if pack is None:
+            try:
+                pack = rule_loader.load_pack("dead_anchors", base_dir=base_dir)
+            except Exception:
+                pack = None
+        self.pack = pack
+        gh = _rule_by_id(pack, "DA-GH-001")
+        sh = _rule_by_id(pack, "DA-GH-002")
+        pk = _rule_by_id(pack, "DA-PK-001")
+        dm = _rule_by_id(pack, "DA-DM-001")
+        self.re_gh = getattr(gh, "regex", None) if gh else None
+        self.re_sh = getattr(sh, "regex", None) if sh else None
+        self.re_pk = getattr(pk, "regex", None) if pk else None
+        self.re_dm = getattr(dm, "regex", None) if dm else None
+        cl = _rule_by_id(pack, "DA-CL-001")
+        rw = _rule_by_id(pack, "DA-RW-001")
+        sd = _rule_by_id(pack, "DA-SD-001")
+        tld = _rule_by_id(pack, "DA-TLD-001")
+        # rule.values are NFKC-lowercased tuples; domains/suffixes are already
+        # lowercase so this is lossless. _keyword_values tolerates a tampered
+        # pack that authors any of these ids as a non-keyword type.
+        self.cloud_suffixes = _keyword_values(cl)
+        self.reserved_words = _keyword_values(rw)
+        self.safe_domains = _keyword_values(sd)
+        self.multi_tlds = _keyword_values(tld)
+
+    # -- individual extractors (operate on one line of text) ------------------
+
+    def _github_from(self, regex, line, ecosystem_hint):
+        out = []
+        if regex is None:
+            return out
+        for m in regex.finditer(line):
+            owner, repo = m.group(1), m.group(2)
+            if not owner or not repo:
+                continue
+            if owner.lower() in self.reserved_words:
+                continue
+            # Trailing punctuation cleanup (e.g. "repo)." in prose).
+            repo = repo.rstrip(".")
+            if not repo:
+                continue
+            out.append((owner, repo, m.group(0)))
+        return out
+
+    def _packages_from(self, line):
+        out = []
+        if self.re_pk is None:
+            return out
+        for m in self.re_pk.finditer(line):
+            verb = m.group(0).split()[0].lower()
+            raw_name = m.group(1)
+            name = _strip_pkg_version(raw_name)
+            if not name:
+                continue
+            if verb.startswith("pip"):
+                eco = "PyPI"
+            elif verb in ("npm", "yarn", "pnpm"):
+                eco = "npm"
+            else:
+                eco = None  # gem/cargo/bundle: extracted, not probed in P0
+            out.append((name, eco, m.group(0)))
+        return out
+
+    def _domains_from(self, line):
+        """Yield (kind, payload, raw) where kind is 'cloud' or 'domain'."""
+        out = []
+        if self.re_dm is None:
+            return out
+        for m in self.re_dm.finditer(line):
+            host = m.group(1).lower().rstrip(".")
+            if not host or "." not in host:
+                continue
+            suffix = self._cloud_suffix_for(host)
+            if suffix is not None:
+                if host == suffix:
+                    continue  # bare platform domain, not our subdomain to claim
+                out.append(("cloud", (host, suffix), m.group(0)))
+                continue
+            reg = self._registrable(host)
+            if not reg or reg in self.safe_domains:
+                continue
+            out.append(("domain", reg, m.group(0)))
+        return out
+
+    def _cloud_suffix_for(self, host):
+        for suf in self.cloud_suffixes:
+            if host == suf or host.endswith("." + suf):
+                return suf
+        return None
+
+    def _registrable(self, host):
+        labels = host.split(".")
+        if len(labels) < 2:
+            return None
+        # Longest matching multi-part TLD wins.
+        for n in (3, 2):
+            if len(labels) > n:
+                candidate = ".".join(labels[-n:])
+                if candidate in self.multi_tlds:
+                    return ".".join(labels[-(n + 1):])
+        return ".".join(labels[-2:])
+
+
+def _strip_pkg_version(raw):
+    """Strip version specifiers/flags from a captured package token, preserving
+    an npm scope (@scope/name)."""
+    name = raw.strip().strip(",;)")
+    if not name:
+        return ""
+    # pip-style specifiers.
+    for sep in ("==", ">=", "<=", "~=", "!=", ">", "<", "["):
+        idx = name.find(sep)
+        if idx > 0:
+            name = name[:idx]
+    # npm @version, keeping a leading scope @.
+    if name.startswith("@"):
+        parts = name[1:].split("@", 1)
+        name = "@" + parts[0]
+    else:
+        name = name.split("@", 1)[0]
+    return name.rstrip("/.")
+
+
+def _iter_seed_files(repo_path):
+    """Yield (abs_path, rel_path) for seed / manifest files, bounded.
+
+    Non-regular files (FIFOs, sockets, device nodes) are skipped BEFORE they are
+    ever handed to a reader: a FIFO named 'SKILL.md' shipped in a malicious repo
+    would otherwise block open()/read() forever and hang the whole scan
+    (python-redos F1). os.stat follows a symlink to its target, so a symlink
+    pointing at a FIFO/device is caught here too; only a real regular file (of
+    the target) passes."""
+    seeds_lower = {s.lower() for s in _SEED_FILES} | {e.lower() for e in _EXTRA_FILES}
+    count = 0
+    for root, dirs, files in os.walk(repo_path):
+        dirs[:] = [d for d in dirs if d not in _SKIP_DIRS]
+        for fn in files:
+            if fn.lower() in seeds_lower:
+                abs_path = os.path.join(root, fn)
+                try:
+                    st = os.stat(abs_path)  # follows symlink to its final target
+                except OSError:
+                    continue
+                if not stat.S_ISREG(st.st_mode):
+                    continue  # FIFO / socket / device / dir -> never open
+                if st.st_size > _MAX_FILE_BYTES:
+                    continue  # size cap enforced BEFORE any read
+                rel = os.path.relpath(abs_path, repo_path)
+                yield abs_path, rel
+                count += 1
+                if count >= _MAX_FILES:
+                    return
+
+
+def _read_regular_file(abs_path):
+    """Open a seed file defensively and return its text, or None to skip it.
+
+    Belt-and-suspenders over _iter_seed_files: O_NONBLOCK guarantees the open()
+    itself can never block on a FIFO/device even under a TOCTOU swap after the
+    stat, and an fstat on the fd we actually hold re-confirms it is a regular
+    file and re-checks the size cap on that exact fd."""
+    try:
+        fd = os.open(abs_path, os.O_RDONLY | _O_NONBLOCK)
+    except OSError:
+        return None
+    try:
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode) or st.st_size > _MAX_FILE_BYTES:
+            os.close(fd)
+            return None
+    except OSError:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        return None
+    try:
+        with os.fdopen(fd, "r", encoding="utf-8", errors="replace") as f:
+            return f.read()
+    except (OSError, ValueError):
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        return None
+
+
+def extract_anchors(repo_path, pack=None, base_dir=None):
+    """Extract the deduped list of Anchor records from a repo. Zero network.
+
+    De-dup key is (type, target) so N references to the same anchor => 1 probe.
+    The FIRST occurrence's file/line/raw is kept for the finding location.
+    """
+    try:
+        ex = _Extractor(pack=pack, base_dir=base_dir)
+    except Exception:
+        return []  # tampered/malformed pack: nothing to probe this run (no crash)
+    if not (ex.re_gh or ex.re_sh or ex.re_pk or ex.re_dm):
+        return []  # pack unavailable: nothing to probe this run
+
+    seen = {}  # normalized (type, key) -> Anchor (first wins)
+
+    def _add(anchor):
+        # Dedup on the NORMALIZED identity so case/separator variants of the same
+        # real anchor collapse to one probe + one finding. The original casing is
+        # preserved on the stored Anchor for display.
+        if anchor.type == "github":
+            key = ("github", "%s/%s" % ((anchor.owner or "").lower(),
+                                        (anchor.repo or "").lower()))
+        elif anchor.type == "package":
+            eco, _, nm = anchor.target.partition(":")
+            if eco == "npm":
+                nm = normalize_npm_name(nm)
+            elif eco == "PyPI":
+                nm = normalize_pypi_name(nm)
+            key = ("package", "%s:%s" % (eco, nm))
+        else:
+            key = (anchor.type, anchor.target)
+        if key not in seen:
+            seen[key] = anchor
+
+    for abs_path, rel in _iter_seed_files(repo_path):
+        if len(seen) >= _MAX_ANCHORS:
+            break
+        text = _read_regular_file(abs_path)
+        if text is None:
+            continue
+        lines = text.splitlines(keepends=True)
+        for lineno, line in enumerate(lines, 1):
+            if len(seen) >= _MAX_ANCHORS:
+                break
+            if len(line) > 8000:
+                line = line[:8000]
+            fetch_ctx = bool(_FETCH_VERB_RE.search(line))
+            # GitHub URL + shorthand.
+            for owner, repo, raw in ex._github_from(ex.re_gh, line, None):
+                _add(Anchor("github", f"{owner}/{repo}", owner, repo, None,
+                            None, False, rel, lineno, raw, fetch_ctx))
+            for owner, repo, raw in ex._github_from(ex.re_sh, line, None):
+                _add(Anchor("github", f"{owner}/{repo}", owner, repo, None,
+                            None, False, rel, lineno, raw, fetch_ctx))
+            # Packages.
+            for name, eco, raw in ex._packages_from(line):
+                if eco is None:
+                    continue  # gem/cargo/bundle not probed in P0
+                _add(Anchor("package", f"{eco}:{name}", None, None, eco,
+                            None, False, rel, lineno, raw, fetch_ctx))
+            # Domains + cloud subdomains.
+            for kind, payload, raw in ex._domains_from(line):
+                if kind == "cloud":
+                    host, suffix = payload
+                    _add(Anchor("cloud", host, None, None, None, suffix,
+                                True, rel, lineno, raw, fetch_ctx))
+                else:
+                    _add(Anchor("domain", payload, None, None, None, None,
+                                False, rel, lineno, raw, fetch_ctx))
+
+    return list(seen.values())

--- a/skills/repo-forensics/scripts/dead_anchors_probe.py
+++ b/skills/repo-forensics/scripts/dead_anchors_probe.py
@@ -1,0 +1,702 @@
+#!/usr/bin/env python3
+"""
+dead_anchors_probe.py - Network claimability layer for the dead-anchor scanner
+(U2).
+
+Turns an extracted Anchor into a CC / LO / NC verdict:
+  CC = CONFIRMED-CLAIMABLE (404 / NXDOMAIN / RDAP-404 / provider fingerprint) -> the
+       one signal that emits a Finding downstream.
+  LO = LIVE-AND-OWNED (200 / registered) -> silent (normal state of the world).
+  NC = COULDN'T-CHECK (403 / 429 / 5xx / timeout / offline / over-budget) -> silent.
+
+Loop-safety & race-safety contract (spec §10), all STRUCTURAL not incidental:
+  * Single attempt per probe. There is NO retry loop anywhere in this module.
+  * HTTPError caught FIRST, branched on .code (KTD-3): 404 => CC (signal),
+    403/429 => NC + trips the per-host circuit breaker, 5xx/other => NC. A 404
+    NEVER collapses into the generic "network failed => NC" branch (inverts the
+    vuln_feed.fetch_npm/pypi_freshness anti-pattern).
+  * Per-host circuit breaker: first 403/429 from a host trips it; every later
+    probe to that host short-circuits to NC with zero further calls, no reset.
+  * One shared wall-clock deadline + a GH call cap + a total-probe ceiling; all
+    checked BEFORE any socket is touched (network last).
+  * 24h atomic result cache, reusing vuln_feed._atomic_write / _load_cache
+    directly (temp+os.replace+0o600, no lock, tolerant reads). Only CC/LO are
+    cached; NC (transient) always re-probes next scan.
+  * offline=True is the cheapest path: instant NC before cache/deadline/budget.
+
+All HTTPS goes through vuln_feed._https_fetch (no 4th hand-rolled urlopen). DNS
+for cloud subdomains uses socket.gethostbyname (no HTTP equivalent), wrapped in
+the same never-raise discipline.
+
+Created by Alex Greenshpun
+"""
+
+import os
+import re
+import sys
+import json
+import time
+import stat
+import socket
+import hashlib
+import tempfile
+import ipaddress
+import threading
+import http.client
+import urllib.error
+import urllib.parse
+import urllib.request
+
+_SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import vuln_feed
+import forensics_core as core
+from dead_anchors_extract import normalize_npm_name, normalize_pypi_name
+
+# ---- Tunables (read at construction so tests can monkeypatch) --------------
+NETWORK_DEADLINE_SEC = 12.0        # whole-pass wall-clock budget
+GITHUB_CALL_CAP = 20               # unauthenticated GH calls/scan
+GITHUB_CALL_CAP_TOKEN = 40         # raised (not authenticated) when a token exists
+TOTAL_PROBE_CEILING = 50           # across ALL anchor types/scan
+RESULT_CACHE_TTL_HOURS = 24
+
+_HTTP_MAX_BYTES = 512 * 1024       # cap on any probe response body
+_CLOUD_BODY_MAX_BYTES = 128 * 1024
+
+_HOST_GITHUB = "api.github.com"
+_HOST_NPM = "registry.npmjs.org"
+_HOST_PYPI = "pypi.org"
+_HOST_RDAP = "rdap.org"
+
+# Input-validation charsets (defense-in-depth before a value hits a URL).
+_OWNER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,100}$")
+_PKG_RE = re.compile(r"^@?[A-Za-z0-9][A-Za-z0-9@/._-]{0,120}$")
+_DOMAIN_RE = re.compile(r"^[a-z0-9][a-z0-9.-]{0,190}$")
+
+
+# ---------------------------------------------------------------------------
+# SSRF / redirect hardening (security-sentinel F1/F4, code-review F1).
+#
+# Python's DEFAULT urllib opener transparently follows up to 10 redirects, each
+# a fresh request to a SERVER-CONTROLLED Location that bypasses the per-host
+# breaker, the probe budget, the whole-pass deadline AND the https-only check
+# (https->http downgrade + pivot to internal / link-local / metadata IPs are all
+# allowed). Every dead_anchors probe therefore uses an EXPLICIT opener:
+#   * fixed-host + attacker-host probes (GitHub/npm/PyPI/cloud) -> NO redirects.
+#     A 3xx surfaces as its own HTTPError and is classified COULDN'T-CHECK; the
+#     Location is never auto-fetched.
+#   * rdap.org -> a BOUNDED, re-validated redirect (its whole purpose is to
+#     bootstrap-redirect to the correct registry RDAP server): <=3 hops, each
+#     https-only and each rejected if the target host resolves into a private /
+#     loopback / link-local / metadata range.
+# ---------------------------------------------------------------------------
+
+def _is_internal_ip(ip):
+    """True for any address a forensics probe must never connect to."""
+    try:
+        addr = ipaddress.ip_address(ip)
+    except (ValueError, TypeError):
+        return True  # unparseable => refuse (fail closed)
+    return (addr.is_private or addr.is_loopback or addr.is_link_local
+            or addr.is_multicast or addr.is_reserved or addr.is_unspecified)
+
+
+def _hostname_is_internal(host):
+    """Resolve host (A+AAAA) and return True if ANY address is internal, or if it
+    cannot be resolved/validated (fail closed — block the redirect hop)."""
+    try:
+        infos = socket.getaddrinfo(host, 443, proto=socket.IPPROTO_TCP)
+    except Exception:
+        return True
+    checked = False
+    for info in infos:
+        sockaddr = info[4] if len(info) > 4 else None
+        if sockaddr:
+            checked = True
+            if _is_internal_ip(sockaddr[0]):
+                return True
+    return not checked
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Refuse ALL redirects. Returning None makes urllib raise the 3xx as an
+    HTTPError instead of following the Location header."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+class _BoundedRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Follow at most a few redirects, each re-validated: https-only, and the
+    target host must not resolve into an internal range."""
+
+    max_redirections = 3
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        try:
+            parts = urllib.parse.urlsplit(newurl)
+        except Exception:
+            return None
+        if parts.scheme != "https":
+            return None
+        host = parts.hostname
+        if not host or _hostname_is_internal(host):
+            return None
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+_NO_REDIRECT_OPENER = None
+_BOUNDED_REDIRECT_OPENER = None
+
+
+def _no_redirect_opener():
+    global _NO_REDIRECT_OPENER
+    if _NO_REDIRECT_OPENER is None:
+        _NO_REDIRECT_OPENER = urllib.request.build_opener(_NoRedirectHandler)
+    return _NO_REDIRECT_OPENER
+
+
+def _bounded_redirect_opener():
+    global _BOUNDED_REDIRECT_OPENER
+    if _BOUNDED_REDIRECT_OPENER is None:
+        _BOUNDED_REDIRECT_OPENER = urllib.request.build_opener(_BoundedRedirectHandler)
+    return _BOUNDED_REDIRECT_OPENER
+
+
+class _DirectOpener:
+    """Test seam: an opener whose .open() routes back through
+    vuln_feed.urllib.request.urlopen so the suite's single mock chokepoint still
+    intercepts every dead_anchors probe. Production always uses the real
+    no-redirect / bounded-redirect openers above."""
+
+    def open(self, req, timeout=None):
+        return vuln_feed.urllib.request.urlopen(req, timeout=timeout)
+
+
+class _Deadline:
+    """Single shared wall-clock budget for the whole claimability pass (mirrors
+    scan_provenance._Deadline). NETWORK_DEADLINE_SEC read at construction so a
+    test can monkeypatch it."""
+
+    def __init__(self):
+        self._end = time.monotonic() + NETWORK_DEADLINE_SEC
+
+    def remaining(self):
+        return max(0.0, self._end - time.monotonic())
+
+    def expired(self):
+        return self.remaining() <= 0.0
+
+
+class _ProbeBudget:
+    """GH-specific cap + total-probe ceiling. Consumed only when a probe is
+    actually about to issue a request."""
+
+    def __init__(self, github_cap, total_ceiling):
+        self.gh_remaining = github_cap
+        self.total_remaining = total_ceiling
+
+    def take(self, github=False):
+        if self.total_remaining <= 0:
+            return False
+        if github and self.gh_remaining <= 0:
+            return False
+        self.total_remaining -= 1
+        if github:
+            self.gh_remaining -= 1
+        return True
+
+
+class _CircuitBreaker:
+    """Per-scan, per-host trip state. First 403/429 from a host trips it; never
+    resets within the scan (no backoff, no Retry-After honoring)."""
+
+    def __init__(self):
+        self._tripped = set()
+
+    def trip(self, host):
+        self._tripped.add(host)
+
+    def is_tripped(self, host):
+        return host in self._tripped
+
+
+class ProbeContext:
+    """Bundles the per-scan state threaded through every probe. All state is
+    LOCAL to one scan_repo() call — no module-level mutable globals (spec §10
+    'no shared mutable state across scanners')."""
+
+    def __init__(self, offline=False, cache_dir=None, github_token=None):
+        self.offline = offline
+        self.deadline = _Deadline()
+        token = github_token if github_token is not None else os.environ.get("GITHUB_TOKEN")
+        self.has_token = bool(token)
+        # The token is NEVER attached to a request (no Authorization header is
+        # added anywhere in the fetch path), so authenticated calls are not
+        # actually made — a token must therefore NOT raise the call budget.
+        # Inflating it only made the scanner hammer GitHub's real 60/hr limit,
+        # trip the circuit breaker sooner and silently under-detect
+        # (security-sentinel F7). Keep the cap fixed until real auth is wired.
+        self.budget = _ProbeBudget(GITHUB_CALL_CAP, TOTAL_PROBE_CEILING)
+        self.breaker = _CircuitBreaker()
+        self.cache_dir = cache_dir if cache_dir is not None else _default_cache_dir()
+
+    # -- 24h result cache (only CC/LO cached; NC always re-probes) ------------
+
+    def _cache_path(self, key):
+        digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
+        return os.path.join(self.cache_dir, f"{digest}.json")
+
+    def cache_get(self, key):
+        """Return a cached (verdict, extra) tuple within TTL, else None.
+        Tolerant: any read error / malformed / wrong-shape entry => cache-miss,
+        never a crash (KTD-14). Refuses to read through a symlinked cache dir or
+        entry (verdict-poisoning backstop, security-sentinel F6)."""
+        try:
+            path = self._cache_path(key)
+            if os.path.islink(self.cache_dir) or os.path.islink(path):
+                return None
+            data = vuln_feed._load_cache(path, RESULT_CACHE_TTL_HOURS)
+        except Exception:
+            return None
+        if not isinstance(data, dict):
+            return None
+        verdict = data.get("verdict")
+        if verdict not in ("CC", "LO"):
+            return None
+        extra = data.get("extra")
+        return verdict, (extra if isinstance(extra, dict) else None)
+
+    def cache_put(self, key, verdict, extra=None):
+        if verdict not in ("CC", "LO"):
+            return  # never cache a transient NC
+        try:
+            path = self._cache_path(key)
+            if os.path.islink(self.cache_dir) or os.path.islink(path):
+                return  # never write through a symlinked cache dir/entry
+        except OSError:
+            return
+        payload = {"_cached_at": time.time(), "verdict": verdict,
+                   "extra": extra if isinstance(extra, dict) else {}}
+        try:
+            vuln_feed._atomic_write(path, payload)
+        except OSError:
+            pass  # cache write failure is non-fatal
+
+
+def _default_cache_dir():
+    """Never raise: in a UID-less container `~` may not expand
+    (pwd.getpwuid -> KeyError), which must degrade to a temp dir, not crash the
+    scan (python-redos F4)."""
+    try:
+        home = os.path.expanduser("~")
+        if not home or home == "~":
+            raise ValueError("no home directory")
+        return os.path.join(home, ".cache", "repo-forensics", "dead-anchors")
+    except Exception:
+        return os.path.join(tempfile.gettempdir(), "repo-forensics-dead-anchors")
+
+
+ProbeResult = None  # (kept as documentation; probes return (verdict, extra))
+
+
+# ---------------------------------------------------------------------------
+# Core HTTPS wrapper — the single most load-bearing correctness property.
+# HTTPError caught BEFORE URLError, branched on .code. Single attempt.
+# ---------------------------------------------------------------------------
+
+def _call_timeout(ctx):
+    """Per-call socket timeout = min(network timeout, remaining pass deadline) so
+    one hung probe can never overrun the whole-pass budget by a full timeout
+    (code-review F2, integration F4)."""
+    remaining = ctx.deadline.remaining()
+    base = getattr(vuln_feed, "NETWORK_TIMEOUT_SEC", 10)
+    if remaining <= 0:
+        return 0.001
+    return min(base, remaining)
+
+
+def _probe_https(url, host, ctx, max_bytes=_HTTP_MAX_BYTES, opener=None):
+    """Issue ONE GET via the hardened vuln_feed._https_fetch, with NO redirect
+    following (opener defaults to the no-redirect opener). Returns
+    (verdict, raw_bytes_or_None). On 403/429 trips the host breaker. A 3xx
+    (redirect refused) is classified NC — never auto-fetched. Never raises."""
+    if opener is None:
+        opener = _no_redirect_opener()
+    try:
+        raw = vuln_feed._https_fetch(url, max_bytes, opener=opener,
+                                     timeout=_call_timeout(ctx))
+        return "LO", raw
+    except urllib.error.HTTPError as e:  # MUST precede URLError (subclass)
+        code = getattr(e, "code", None)
+        if code == 404:
+            return "CC", None
+        if code in (403, 429):
+            ctx.breaker.trip(host)
+            return "NC", None
+        return "NC", None  # incl. 3xx (redirect refused) => couldn't-check
+    except (urllib.error.URLError, OSError, ValueError, http.client.HTTPException):
+        return "NC", None
+
+
+def _pre_network_ok(ctx, host, github=False):
+    """Shared cheap gate run before any request: deadline -> breaker -> budget.
+    Returns True iff a request may be issued. 'network last'."""
+    if ctx.deadline.expired():
+        return False
+    if ctx.breaker.is_tripped(host):
+        return False
+    if not ctx.budget.take(github=github):
+        return False
+    return True
+
+
+def _parse_json(raw):
+    if not raw:
+        return None
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Per-anchor-type probes. Order in each: offline -> cache -> pre-network -> fetch.
+# ---------------------------------------------------------------------------
+
+def probe_github_user(owner, ctx):
+    """GET api.github.com/users/{owner}. On LO returns the parsed JSON (for
+    DA-10 owner-trust enrichment)."""
+    if ctx.offline:
+        return "NC", None
+    if not _OWNER_RE.match(owner or ""):
+        return "NC", None
+    key = f"gh_user::{owner.lower()}"
+    cached = ctx.cache_get(key)
+    if cached is not None:
+        return cached
+    if not _pre_network_ok(ctx, _HOST_GITHUB, github=True):
+        return "NC", None
+    url = f"https://api.github.com/users/{urllib.parse.quote(owner, safe='')}"
+    verdict, raw = _probe_https(url, _HOST_GITHUB, ctx)
+    meta = _github_owner_meta(_parse_json(raw)) if verdict == "LO" else None
+    if verdict in ("CC", "LO"):
+        ctx.cache_put(key, verdict, meta)
+    return verdict, meta
+
+
+def probe_github_repo(owner, repo, ctx):
+    """GET api.github.com/repos/{owner}/{repo}. Only meaningful when the owner
+    probe returned LO (caller enforces)."""
+    if ctx.offline:
+        return "NC", None
+    if not (_OWNER_RE.match(owner or "") and _OWNER_RE.match(repo or "")):
+        return "NC", None
+    key = f"gh_repo::{owner.lower()}/{repo.lower()}"
+    cached = ctx.cache_get(key)
+    if cached is not None:
+        return cached
+    if not _pre_network_ok(ctx, _HOST_GITHUB, github=True):
+        return "NC", None
+    url = (f"https://api.github.com/repos/{urllib.parse.quote(owner, safe='')}/"
+           f"{urllib.parse.quote(repo, safe='')}")
+    verdict, _raw = _probe_https(url, _HOST_GITHUB, ctx)
+    if verdict in ("CC", "LO"):
+        ctx.cache_put(key, verdict, None)
+    return verdict, None
+
+
+def probe_npm(name, ctx):
+    if ctx.offline:
+        return "NC", None
+    if not _PKG_RE.match(name or "") or ".." in name:
+        return "NC", None
+    # npm names are case-insensitive & lowercase: probe (and cache) the canonical
+    # form so 'npm install React' resolves to the live 'react', not a phantom
+    # 404 (integration F2).
+    probe_name = normalize_npm_name(name)
+    if not probe_name:
+        return "NC", None
+    key = f"npm::{probe_name}"
+    cached = ctx.cache_get(key)
+    if cached is not None:
+        return cached
+    if not _pre_network_ok(ctx, _HOST_NPM):
+        return "NC", None
+    url = f"https://registry.npmjs.org/{urllib.parse.quote(probe_name, safe='@')}"
+    verdict, _raw = _probe_https(url, _HOST_NPM, ctx)
+    if verdict in ("CC", "LO"):
+        ctx.cache_put(key, verdict, None)
+    return verdict, None
+
+
+def probe_pypi(name, ctx):
+    if ctx.offline:
+        return "NC", None
+    if not _PKG_RE.match(name or "") or ".." in name:
+        return "NC", None
+    # PEP 503 canonicalization before probing: 'My_Package', 'my-package',
+    # 'my.package' are one live distribution, not a phantom (integration F3).
+    probe_name = normalize_pypi_name(name)
+    if not probe_name:
+        return "NC", None
+    key = f"pypi::{probe_name}"
+    cached = ctx.cache_get(key)
+    if cached is not None:
+        return cached
+    if not _pre_network_ok(ctx, _HOST_PYPI):
+        return "NC", None
+    url = f"https://pypi.org/pypi/{urllib.parse.quote(probe_name, safe='')}/json"
+    verdict, _raw = _probe_https(url, _HOST_PYPI, ctx)
+    if verdict in ("CC", "LO"):
+        ctx.cache_put(key, verdict, None)
+    return verdict, None
+
+
+def _rdap_probe(url, ctx):
+    """rdap.org fetch with BOUNDED, re-validated redirects. Returns
+    (verdict, extra). A 404 is CC only when it was delivered by a delegated
+    registry RDAP server (i.e. a redirect off rdap.org actually happened —
+    genuine 'domain does not exist'); a bare 404 straight from rdap.org means it
+    could not bootstrap a server for that TLD (ccTLD gap / transient) and must
+    NOT fire a false CRITICAL on a live domain (security-sentinel F2)."""
+    opener = _bounded_redirect_opener()
+    try:
+        raw = vuln_feed._https_fetch(url, _HTTP_MAX_BYTES, opener=opener,
+                                     timeout=_call_timeout(ctx))
+        return "LO", _rdap_expiry_meta(_parse_json(raw))
+    except urllib.error.HTTPError as e:
+        code = getattr(e, "code", None)
+        if code in (403, 429):
+            ctx.breaker.trip(_HOST_RDAP)
+            return "NC", None
+        if code == 404:
+            final = getattr(e, "url", "") or ""
+            try:
+                host = (urllib.parse.urlsplit(final).hostname or "").lower()
+            except Exception:
+                host = ""
+            if host and host != _HOST_RDAP:
+                return "CC", None      # registry itself said 'not found'
+            return "NC", None          # rdap.org bootstrap gap => ambiguous
+        return "NC", None
+    except (urllib.error.URLError, OSError, ValueError, http.client.HTTPException):
+        return "NC", None
+
+
+def probe_domain_rdap(domain, ctx):
+    """GET rdap.org/domain/{domain}. Registry 404 (after bootstrap redirect) =>
+    CC (unregistered/expired). On LO, inspect the events array for a PAST
+    expiration date (imminent-expiry flag)."""
+    if ctx.offline:
+        return "NC", None
+    if not _DOMAIN_RE.match(domain or ""):
+        return "NC", None
+    key = f"rdap::{domain.lower()}"
+    cached = ctx.cache_get(key)
+    if cached is not None:
+        return cached
+    if not _pre_network_ok(ctx, _HOST_RDAP):
+        return "NC", None
+    url = f"https://rdap.org/domain/{urllib.parse.quote(domain, safe='')}"
+    verdict, extra = _rdap_probe(url, ctx)
+    if verdict in ("CC", "LO"):
+        ctx.cache_put(key, verdict, extra)
+    return verdict, extra
+
+
+def _resolve_with_timeout(host, timeout):
+    """Resolve host (A+AAAA via getaddrinfo, not IPv4-only gethostbyname) with a
+    HARD wall-clock bound so a hung resolver can never overrun the pass deadline
+    (integration F4). Returns (status, addrs):
+      'ok'       -> addrs is the list of resolved IP strings
+      'nxdomain' -> the name provably does not resolve (EAI_NONAME)
+      'nc'       -> couldn't-check (timeout / temporary failure / other)
+    An AAAA-only (IPv6-only) host resolves to 'ok', NOT a false 'nxdomain'
+    (security-sentinel F3). A hung resolver returns 'nc', never 'nxdomain'."""
+    result = {}
+
+    def _run():
+        try:
+            infos = socket.getaddrinfo(host, 443, proto=socket.IPPROTO_TCP)
+            result["addrs"] = [i[4][0] for i in infos
+                               if i and len(i) > 4 and i[4]]
+        except socket.gaierror as e:
+            if getattr(e, "errno", None) == socket.EAI_NONAME:
+                result["nx"] = True
+            else:
+                result["err"] = True
+        except (OSError, UnicodeError, ValueError):
+            result["err"] = True
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    t.join(timeout if timeout and timeout > 0 else None)
+    if t.is_alive():
+        return "nc", None            # resolver hung -> couldn't-check
+    if result.get("addrs"):
+        return "ok", result["addrs"]
+    if result.get("nx"):
+        return "nxdomain", None
+    return "nc", None
+
+
+def _cloud_http(url, suffix, ctx):
+    """Fetch a cloud subdomain root with NO redirects, capturing the response
+    body EVEN ON a non-200 status (a deleted-app error page is what we need to
+    fingerprint — the generic _probe_https discards the 404 body). Returns
+    (body_bytes, ok); ok is False on transport failure / 403 / 429 (=> NC)."""
+    try:
+        raw = vuln_feed._https_fetch(url, _CLOUD_BODY_MAX_BYTES,
+                                     opener=_no_redirect_opener(),
+                                     timeout=_call_timeout(ctx))
+        return raw, True
+    except urllib.error.HTTPError as e:
+        code = getattr(e, "code", None)
+        if code in (403, 429):
+            ctx.breaker.trip(suffix)
+            return None, False
+        try:
+            body = e.read(_CLOUD_BODY_MAX_BYTES + 1)
+            if body and len(body) > _CLOUD_BODY_MAX_BYTES:
+                body = body[:_CLOUD_BODY_MAX_BYTES]
+        except Exception:
+            body = b""
+        return body or b"", True
+    except (urllib.error.URLError, OSError, ValueError, http.client.HTTPException):
+        return None, False
+
+
+def probe_cloud_subdomain(subdomain, suffix, ctx, fingerprints=None):
+    """Claimability for a free-tier cloud subdomain.
+
+    The ONLY stand-alone high-confidence claimable signal is DNS NXDOMAIN. A
+    resolving host is fetched and its body checked against STRICT provider
+    deleted-app fingerprints; a bare 404/200 from a resolving host with no strict
+    fingerprint stays LO (silent), never a false CRITICAL (error-soundness F2,
+    integration F1). Biased hard toward silence over a false CRITICAL."""
+    if ctx.offline:
+        return "NC", None
+    if not _DOMAIN_RE.match(subdomain or ""):
+        return "NC", None
+    key = f"cloud::{subdomain.lower()}"
+    cached = ctx.cache_get(key)
+    if cached is not None:
+        return cached
+    # DNS resolution (no HTTP equivalent). Counts against the total ceiling +
+    # deadline, but is not a GH call. Breaker keyed on the registrable suffix.
+    if ctx.deadline.expired() or ctx.breaker.is_tripped(suffix):
+        return "NC", None
+    if not ctx.budget.take(github=False):
+        return "NC", None
+    status, addrs = _resolve_with_timeout(subdomain, _call_timeout(ctx))
+    if status == "nxdomain":
+        ctx.cache_put(key, "CC", {"reason": "nxdomain"})
+        return "CC", {"reason": "nxdomain"}
+    if status != "ok":
+        return "NC", None
+    # Structural SSRF backstop, independent of the rulepack: never fetch a
+    # subdomain that resolves into a private / loopback / link-local / metadata
+    # range, whatever the suffix list says (security-sentinel F1/F4).
+    if any(_is_internal_ip(a) for a in (addrs or [])):
+        return "NC", None
+    # Resolves & public: fetch and fingerprint. Second call — guard again.
+    if not _pre_network_ok(ctx, suffix):
+        return "NC", None
+    body, ok = _cloud_http(f"https://{subdomain}", suffix, ctx)
+    if not ok:
+        return "NC", None
+    fp = _fingerprint_match(body, suffix, fingerprints or {})
+    if fp is not None:
+        ctx.cache_put(key, "CC", {"reason": "fingerprint", "confidence": fp})
+        return "CC", {"reason": "fingerprint", "confidence": fp}
+    ctx.cache_put(key, "LO", None)
+    return "LO", None
+
+
+# ---- Enrichment helpers ----------------------------------------------------
+
+def _github_owner_meta(data):
+    """DA-10 owner-trust signals from the SAME users response (created_at,
+    public_repos, bio). Never raises."""
+    if not isinstance(data, dict):
+        return None
+    return {
+        "created_at": data.get("created_at"),
+        "public_repos": data.get("public_repos"),
+        "bio": data.get("bio"),
+    }
+
+
+def _rdap_expiry_meta(data):
+    """Return {'imminent_expiry': True} if the RDAP events array carries a past
+    (already-elapsed) expiration date, else None."""
+    if not isinstance(data, dict):
+        return None
+    events = data.get("events")
+    if not isinstance(events, list):
+        return None
+    now = time.time()
+    for ev in events:
+        if not isinstance(ev, dict):
+            continue
+        if ev.get("eventAction") != "expiration":
+            continue
+        ts = _parse_iso8601(ev.get("eventDate"))
+        if ts is not None and ts < now:
+            return {"imminent_expiry": True}
+    return None
+
+
+def _parse_iso8601(s):
+    if not isinstance(s, str) or not s:
+        return None
+    txt = s.strip().replace("Z", "+00:00")
+    for fmt in ("%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%S.%f%z",
+                "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d"):
+        try:
+            import datetime
+            dt = datetime.datetime.strptime(txt, fmt)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=datetime.timezone.utc)
+            return dt.timestamp()
+        except (ValueError, ImportError):
+            continue
+    return None
+
+
+def _fingerprint_match(raw, suffix, fingerprints):
+    """Return the confidence float if a STRICT provider deleted-app fingerprint
+    for this suffix matches the response body, else None.
+
+    Strictness (integration F1, error-soundness F2/F5): only entries explicitly
+    marked "strict": true fire CC (generic phrases like 'project not found' /
+    'Application not found' were removed from the pack and any without the flag
+    are ignored), and the token must match on non-alphanumeric boundaries — not
+    as a loose substring buried inside a larger word — so a live app that merely
+    happens to contain the phrase as part of its own content does not trip it."""
+    entries = fingerprints.get(suffix)
+    if not isinstance(entries, list):
+        return None
+    try:
+        if isinstance(raw, (bytes, bytearray)):
+            body = raw.decode("utf-8", errors="replace")
+        else:
+            body = str(raw or "")
+    except Exception:
+        return None
+    for ent in entries:
+        if not isinstance(ent, dict):
+            continue
+        if ent.get("strict") is not True:
+            continue
+        needle = ent.get("s")
+        if not isinstance(needle, str) or not needle:
+            continue
+        pattern = r"(?<![0-9A-Za-z])" + re.escape(needle) + r"(?![0-9A-Za-z])"
+        if re.search(pattern, body):
+            conf = ent.get("confidence")
+            return float(conf) if isinstance(conf, (int, float)) else 0.8
+    return None

--- a/skills/repo-forensics/scripts/gen_rule_ids.py
+++ b/skills/repo-forensics/scripts/gen_rule_ids.py
@@ -54,6 +54,11 @@ _SCANNER_ABBREV = {
     "scan_dependencies.py": "DP",
     "scan_devcontainer.py": "DC",
     "_shared_patterns.py": "SH",
+    # dead_anchors authors all its rule ids directly in
+    # data/rulepacks/dead_anchors.json (no module-level *_PATTERNS tables to
+    # scrape), so this abbrev emits ZERO rows in rule_ids.csv — registration for
+    # completeness only. Expected, not a bug.
+    "scan_dead_anchors.py": "DA",
 }
 
 # Table-name fragment -> CATEGORY abbreviation. First matching fragment wins.

--- a/skills/repo-forensics/scripts/run_forensics.sh
+++ b/skills/repo-forensics/scripts/run_forensics.sh
@@ -10,8 +10,8 @@ if [ -z "${1:-}" ]; then
     echo "Usage: $0 <repo_path> [options]"
     echo ""
     echo "Modes:"
-    echo "  (default)              Full audit - all 25 scanners"
-    echo "  --skill-scan           Focused on AI skill threats (15 scanners, faster)"
+    echo "  (default)              Full audit - all 26 scanners"
+    echo "  --skill-scan           Focused on AI skill threats (16 scanners, faster)"
     echo "  --inventory            Enumerate installed AI-agent stacks (zero-LLM, JSON output)"
     echo ""
     echo "Options:"
@@ -315,6 +315,12 @@ run_scanner() {
         $OFFLINE && scanner_args+=("--offline")
     fi
 
+    # dead_anchors is network-touching; honor the global --offline flag so a
+    # sandboxed/offline full scan degrades every anchor to couldn't-check.
+    if [ "$name" = "dead_anchors" ]; then
+        $OFFLINE && scanner_args+=("--offline")
+    fi
+
     if [ -n "$TIMEOUT_CMD" ]; then
         $TIMEOUT_CMD "$SCANNER_TIMEOUT" "${PYTHON[@]}" "$SKILL_DIR/$script" "$REPO_PATH" --format "$internal_format" ${scanner_args[@]+"${scanner_args[@]}"} 3>&- > "$output_file" 2>> "$error_file"
     else
@@ -348,7 +354,7 @@ if $SKILL_SCAN; then
     # Focused mode: 10 scanners most relevant to vetting skills
     if [ "$FORMAT" != "json" ]; then
         echo ""
-        echo "[*] Running focused skill scan (15 scanners)..."
+        echo "[*] Running focused skill scan (16 scanners)..."
     fi
 
     throttled_run run_scanner "skill_threats" "scan_skill_threats.py" &
@@ -366,13 +372,14 @@ if $SKILL_SCAN; then
     throttled_run run_scanner "archive" "scan_archive.py" &
     throttled_run run_scanner "splitstream" "scan_splitstream.py" &
     throttled_run run_scanner "provenance" "scan_provenance.py" &
+    throttled_run run_scanner "dead_anchors" "scan_dead_anchors.py" &
     wait
 
 else
     # Full audit: all scanners in parallel
     if [ "$FORMAT" != "json" ]; then
         echo ""
-        echo "[*] Running all 25 scanners in parallel..."
+        echo "[*] Running all 26 scanners in parallel..."
     fi
     throttled_run run_scanner "entropy" "scan_entropy.py" &
     throttled_run run_scanner "binary" "scan_binary.py" &
@@ -403,6 +410,7 @@ else
     throttled_run run_scanner "archive" "scan_archive.py" &
     throttled_run run_scanner "splitstream" "scan_splitstream.py" &
     throttled_run run_scanner "provenance" "scan_provenance.py" &
+    throttled_run run_scanner "dead_anchors" "scan_dead_anchors.py" &
     wait
 fi
 

--- a/skills/repo-forensics/scripts/scan_dead_anchors.py
+++ b/skills/repo-forensics/scripts/scan_dead_anchors.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""
+scan_dead_anchors.py - Dead-Anchor / Repojacking Scanner (Skilljacking gap).
+
+Extracts every external anchor a skill/repo points at (GitHub owner/repo, prose
+package-install target, bare domain, free-tier cloud subdomain) and checks
+whether that anchor is currently CLAIMABLE BY AN ATTACKER — the structural gap
+AIR's Skilljacking research says "tripped nothing at all" in every existing
+scanner, because the file content never changes; only the world behind the
+anchor does.
+
+Three-tier signal partition (mirrors scan_provenance.py exactly, renamed):
+  CONFIRMED-CLAIMABLE (CC)  -> emits a Finding (severity per the DA table).
+  LIVE-AND-OWNED      (LO)  -> SILENT (the normal state of the world).
+  COULDN'T-CHECK      (NC)  -> SILENT (rate-limited / offline / over-budget).
+
+Never-hard-fail: every failure degrades to silence. Never raises, never a false
+CRITICAL, never a non-zero exit from an internal error. `--offline` degrades
+every anchor to NC instantly (sub-second, zero sockets).
+
+Anchor extraction (dead_anchors_extract) and claimability probes
+(dead_anchors_probe) do the work; this module is the 3-tier classifier + Finding
+emitter, plus DA-09 (free-tier suffix) and DA-10 (GitHub-owner trust) bundled in
+at zero extra network cost.
+
+Zero non-stdlib deps: stdlib + forensics_core / vuln_feed / rule_loader only.
+
+Created by Alex Greenshpun
+"""
+
+import os
+import sys
+import json
+
+_SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import forensics_core as core
+import dead_anchors_extract as extract
+import dead_anchors_probe as probe
+
+SCANNER_NAME = "dead_anchors"
+
+_PACK_PATH = os.path.normpath(
+    os.path.join(_SCRIPTS_DIR, "..", "data", "rulepacks", "dead_anchors.json")
+)
+
+
+def _load_fingerprints():
+    """Read the provider fingerprint map straight from the pack file (structured
+    data no rule_loader type models). Tolerant: any error => empty map."""
+    try:
+        with open(_PACK_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}  # a valid-JSON but non-dict pack (e.g. a list) is not a crash
+        fp = data.get("fingerprints")
+        if isinstance(fp, dict):
+            return {k: v for k, v in fp.items() if not k.startswith("_")}
+    except (OSError, ValueError, AttributeError, TypeError):
+        pass
+    return {}
+
+
+def _snippet(anchor):
+    raw = (anchor.raw or "").strip()
+    return raw[:120]
+
+
+def scan_repo(repo_path, ignore_patterns=None, offline=False):
+    """Extract anchors, probe claimability, emit a Finding only on CC.
+
+    ignore_patterns is accepted for uniform registration but unused (this is an
+    anchor-level check, not a per-file walk). One shared probe context per call
+    holds the deadline / budget / breaker / cache — all local, never module
+    globals (spec §10 no-shared-state)."""
+    findings = []
+    del ignore_patterns  # accepted for registration uniformity, unused
+
+    try:
+        anchors = extract.extract_anchors(repo_path)
+    except Exception:
+        return findings  # never-hard-fail: extraction problem => nothing to probe
+    if not anchors:
+        return findings
+
+    # ProbeContext construction (cache-dir resolution) and pack loading sit
+    # between the two already-guarded blocks; wrap them too so no environmental
+    # or malformed-pack failure can escape as a non-zero exit (error-soundness
+    # F1, python-redos F4).
+    try:
+        ctx = probe.ProbeContext(offline=offline)
+        fingerprints = _load_fingerprints()
+    except Exception:
+        return findings
+
+    owner_verdicts = {}   # owner -> (verdict, meta)  memo (dedup owner probes)
+    emitted_da01 = set()  # owners already reported claimable
+    probed = 0
+    skipped = 0
+
+    for a in anchors:
+        try:
+            emitted, ok = _handle_anchor(
+                a, ctx, fingerprints, findings, owner_verdicts, emitted_da01)
+        except Exception:
+            # A single anchor blowing up must never sink the scan.
+            skipped += 1
+            continue
+        if ok:
+            probed += 1
+        else:
+            skipped += 1
+
+    # Optional operator-only summary (text format only; NEVER a Finding, never
+    # counted toward severity/exit-code). See KTD-4.
+    scan_repo._last_summary = (probed, skipped, len(anchors))
+    return findings
+
+
+scan_repo._last_summary = (0, 0, 0)
+
+
+def _handle_anchor(a, ctx, fingerprints, findings, owner_verdicts, emitted_da01):
+    """Probe one anchor and append any Finding. Returns (emitted, checked) where
+    `checked` is False when the verdict was NC (couldn't-check / skipped)."""
+    if a.type == "github":
+        return _handle_github(a, ctx, findings, owner_verdicts, emitted_da01)
+    if a.type == "package":
+        verdict, _meta = (
+            probe.probe_npm(a.target.split(":", 1)[1], ctx)
+            if a.ecosystem == "npm" else
+            probe.probe_pypi(a.target.split(":", 1)[1], ctx)
+        )
+        if verdict == "CC":
+            name = a.target.split(":", 1)[1]
+            findings.append(core.Finding(
+                scanner=SCANNER_NAME, severity="critical",
+                title=f"Phantom / claimable {a.ecosystem} package: {name}",
+                description=(
+                    f"A prose install command references the {a.ecosystem} "
+                    f"package '{name}', but the registry returns 404 — it was "
+                    "never published or has been removed, so an attacker can "
+                    "register that exact name and every follower of this skill "
+                    "installs their code (phantom-package / dependency-confusion)."
+                ),
+                file=a.file, line=a.line, snippet=_snippet(a),
+                category="dead-anchor", rule_id="", confidence=0.90,
+            ))
+            return True, True
+        return False, verdict != "NC"
+    if a.type == "domain":
+        verdict, extra = probe.probe_domain_rdap(a.target, ctx)
+        if verdict == "CC":
+            is_target = bool(a.fetch_context)
+            findings.append(core.Finding(
+                scanner=SCANNER_NAME,
+                severity="critical" if is_target else "high",
+                title=f"Unregistered / expired domain anchor: {a.target}",
+                description=(
+                    f"The domain '{a.target}' referenced here is not registered "
+                    "(RDAP 404) — it is expired or was never registered, so an "
+                    "attacker can register it and control whatever this skill "
+                    + ("fetches/installs from it."
+                       if is_target else "links to it.")
+                ),
+                file=a.file, line=a.line, snippet=_snippet(a),
+                category="dead-anchor", rule_id="", confidence=0.85,
+            ))
+            return True, True
+        return False, verdict != "NC"
+    if a.type == "cloud":
+        verdict, extra = probe.probe_cloud_subdomain(
+            a.target, a.suffix, ctx, fingerprints=fingerprints)
+        if verdict == "CC":
+            reason = (extra or {}).get("reason")
+            if reason == "nxdomain":
+                conf = 0.90
+                how = "no longer resolves (NXDOMAIN)"
+            else:
+                conf = float((extra or {}).get("confidence", 0.80))
+                how = "returns a provider 'deleted app' page"
+            findings.append(core.Finding(
+                scanner=SCANNER_NAME, severity="critical",
+                title=f"Dangling cloud subdomain: {a.target}",
+                description=(
+                    f"'{a.target}' is on the free-tier host '{a.suffix}' and "
+                    f"{how}: the app/project was deleted, so the slug is "
+                    "reclaimable — an attacker re-deploys under the same URL "
+                    "the skill points at. Free-tier suffixes are trivially "
+                    "re-registrable (DA-09)."
+                ),
+                file=a.file, line=a.line, snippet=_snippet(a),
+                category="dead-anchor", rule_id="", confidence=conf,
+            ))
+            return True, True
+        return False, verdict != "NC"
+    return False, False
+
+
+def _handle_github(a, ctx, findings, owner_verdicts, emitted_da01):
+    owner, repo = a.owner, a.repo
+    # GitHub identity is case-insensitive: memoize the owner verdict and the
+    # emitted-finding set on the lowercased owner so case variants dedup to one
+    # probe and one CRITICAL (code-review F3).
+    okey = (owner or "").lower()
+    if okey in owner_verdicts:
+        overdict, ometa = owner_verdicts[okey]
+    else:
+        overdict, ometa = probe.probe_github_user(owner, ctx)
+        owner_verdicts[okey] = (overdict, ometa)
+
+    if overdict == "CC":
+        # DA-01: the whole owner/org is re-registerable. One finding per owner.
+        if okey not in emitted_da01:
+            emitted_da01.add(okey)
+            findings.append(core.Finding(
+                scanner=SCANNER_NAME, severity="critical",
+                title=f"Claimable GitHub owner: {owner}",
+                description=(
+                    f"The GitHub user/org '{owner}' referenced here returns 404 "
+                    "(api.github.com/users) — deleted or renamed, so the "
+                    "username is re-registerable. An attacker who claims it "
+                    f"controls every '{owner}/*' repo this skill points at "
+                    "(repojacking)."
+                ),
+                file=a.file, line=a.line, snippet=_snippet(a),
+                category="dead-anchor", rule_id="", confidence=0.90,
+            ))
+            return True, True
+        return False, True
+
+    if overdict == "LO":
+        # DA-02: owner lives, but the specific repo may be gone (weaker signal).
+        rverdict, _rmeta = probe.probe_github_repo(owner, repo, ctx)
+        if rverdict == "CC":
+            desc = (
+                f"The repo '{owner}/{repo}' returns 404 while the owner "
+                f"'{owner}' is live — renamed, deleted, or made private. If it "
+                "was renamed/deleted the name can be re-created under the same "
+                "owner and mis-point followers of this skill (weaker signal: "
+                "could also be a legitimately private/moved repo)."
+            )
+            trust = _owner_trust_note(ometa)
+            if trust:
+                desc += " " + trust
+            findings.append(core.Finding(
+                scanner=SCANNER_NAME, severity="medium",
+                title=f"Claimable GitHub repo under live owner: {owner}/{repo}",
+                description=desc,
+                file=a.file, line=a.line, snippet=_snippet(a),
+                category="dead-anchor", rule_id="", confidence=0.55,
+            ))
+            return True, True
+        return False, rverdict != "NC"
+
+    return False, False  # owner NC => couldn't check
+
+
+def _owner_trust_note(meta):
+    """DA-10: enrich (never a standalone finding) when the live owner looks
+    low-trust: recent account + few repos + empty bio."""
+    if not isinstance(meta, dict):
+        return ""
+    created = meta.get("created_at")
+    repos = meta.get("public_repos")
+    bio = meta.get("bio")
+    signals = []
+    ts = probe._parse_iso8601(created) if created else None
+    if ts is not None:
+        import time as _t
+        age_days = (_t.time() - ts) / 86400.0
+        if age_days < 365:
+            signals.append(f"account < 1yr old (~{int(age_days)}d)")
+    if isinstance(repos, int) and not isinstance(repos, bool) and repos <= 2:
+        signals.append(f"only {repos} public repos")
+    if bio in (None, "", False):
+        signals.append("empty bio")
+    if len(signals) >= 2:
+        return "Owner trust signals: " + ", ".join(signals) + "."
+    return ""
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(
+        description="repo-forensics: dead_anchors (repojacking / phantom "
+                    "package / expired domain / dangling cloud subdomain)")
+    parser.add_argument("repo_path", help="Path to repository to scan")
+    parser.add_argument("--format", choices=["text", "json", "summary"],
+                        default="text", help="Output format (default: text)")
+    parser.add_argument("--offline", action="store_true",
+                        help="No network: every anchor degrades to couldn't-check "
+                             "(silent), zero sockets opened")
+    args = parser.parse_args(sys.argv[1:])
+    repo_path = os.path.abspath(args.repo_path)
+
+    core.emit_status(args.format,
+                     f"[*] Checking external anchor claimability for {repo_path}...")
+
+    ignore_patterns = core.load_ignore_patterns(repo_path)
+    all_findings = scan_repo(repo_path, ignore_patterns, offline=args.offline)
+    core.output_findings(all_findings, args.format, SCANNER_NAME)
+
+    if args.format == "text":
+        probed, skipped, total = scan_repo._last_summary
+        if total:
+            note = f"[i] dead_anchors: {total} anchors, {probed} checked"
+            if skipped:
+                note += f", {skipped} skipped (rate-limited/offline/over-budget)"
+            print(note, file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/repo-forensics/scripts/vuln_feed.py
+++ b/skills/repo-forensics/scripts/vuln_feed.py
@@ -168,7 +168,7 @@ def _load_cache(path, max_age_hours):
 # HTTPS fetch (hardened)
 # ========================================================================
 
-def _https_fetch(url, max_bytes, body=None):
+def _https_fetch(url, max_bytes, body=None, opener=None, timeout=None):
     """Hardened HTTPS fetch. Returns bytes or raises urllib.error.URLError.
 
     Hard rules (defense-in-depth, not negotiable):
@@ -176,6 +176,15 @@ def _https_fetch(url, max_bytes, body=None):
       - Response is read with an explicit byte cap; oversize responses raise.
       - A fixed User-Agent and a tight timeout are always applied.
       - Method is inferred: POST iff body is given, else GET.
+
+    Optional (added for the dead_anchors scanner's SSRF/redirect hardening; all
+    pre-existing callers keep the historical behavior via the defaults):
+      - opener: a urllib.request.OpenerDirector to use instead of the default
+        global opener (e.g. a no-redirect / bounded-redirect opener). When None
+        the module-global opener is used exactly as before.
+      - timeout: per-call socket timeout in seconds. When None the module-wide
+        NETWORK_TIMEOUT_SEC is used. Callers pass min(NETWORK_TIMEOUT_SEC,
+        remaining_deadline) so one probe can never overrun the whole-pass budget.
     """
     if not isinstance(url, str) or not url.startswith("https://"):
         raise urllib.error.URLError(f"refusing non-https URL: {url!r}")
@@ -188,8 +197,10 @@ def _https_fetch(url, max_bytes, body=None):
         headers["Content-Type"] = "application/json"
         method = "POST"
 
+    to = NETWORK_TIMEOUT_SEC if timeout is None else max(0.001, float(timeout))
+    open_fn = opener.open if opener is not None else urllib.request.urlopen
     req = urllib.request.Request(url, headers=headers, data=data, method=method)
-    with urllib.request.urlopen(req, timeout=NETWORK_TIMEOUT_SEC) as resp:
+    with open_fn(req, timeout=to) as resp:
         # read(N+1) lets us detect overflow without loading more than needed
         raw = resp.read(max_bytes + 1)
         if len(raw) > max_bytes:

--- a/skills/repo-forensics/tests/corpus/DEAD_ANCHORS_CORPUS.md
+++ b/skills/repo-forensics/tests/corpus/DEAD_ANCHORS_CORPUS.md
@@ -1,0 +1,42 @@
+# Dead-Anchor Test Corpus — status & TODO
+
+Fixtures backing `scan_dead_anchors.py`. All unit/integration tests monkeypatch
+the network (vuln_feed's `urllib.request.urlopen` chokepoint + `socket.gethostbyname`);
+NO test in `tests/test_dead_anchors_*.py` ever performs a real HTTP request or
+DNS lookup.
+
+## Committed benign fixtures (in `benign/`)
+
+- `dead_anchors_live_refs.md` — live GitHub owner/repo + `github:` shorthand,
+  live npm (`lodash`) / PyPI (`requests`) install commands, safe-allowlisted docs
+  domains. Asserted to produce ZERO findings under the LO branch
+  (`test_scan_dead_anchors.py::test_benign_corpus_all_lo_zero_findings`, network
+  mocked to 200/registered). Budgeted at zero for the per-file committed-corpus
+  gate too (see `budgets.json`).
+
+## Positive (teeth) coverage
+
+Lives in `tests/test_scan_dead_anchors.py` and `tests/test_dead_anchors_probe.py`
+(canned 404 / NXDOMAIN / provider-fingerprint bodies per anchor type → correct
+CRITICAL/HIGH/MEDIUM finding). Negative coverage: canned 200/registered → zero
+findings; canned 403/429/5xx/timeout → zero findings + no crash (never-hard-fail).
+
+## TODO — external datasets (MANUAL, security-gated — do NOT automate)
+
+These are deliberately NOT wired into CI yet. Each requires a manual, blocking
+`repo-forensics`-first security review before any external bytes enter this
+corpus (Alex's standing external-code rule applied to the test data itself).
+
+1. **SkillSieve** (`github.com/xiaohou521/skillsieve`, 49,592 skills + 400
+   labeled). Before copying ANY labeled skill folder into `tests/corpus/`: clone
+   into an isolated temp dir, run a full `repo-forensics` scan on the clone,
+   review findings, and only then extract reviewed folders. Do NOT clone/fetch
+   from a test or CI path.
+
+2. **ToxicSkills 8 live-malicious IOC URLs** (Snyk, e.g. `clawhub.ai/zaycv/clawhud`).
+   These belong in `ioc_manager.py`'s SIGNED remote IOC feed (a feed-authoring
+   step publishing to the `iocs/latest.json` the manager pulls — NOT a direct
+   edit to any file under `scripts/`/`data/`). Once fed, add a negative-control
+   test asserting `scan_dead_anchors` does not double-fire or conflict with
+   `ioc_manager`'s existing IOC flag on the same anchor (IOC-badness ≠
+   claimability; distinguishable by `scanner` field + `category`).

--- a/skills/repo-forensics/tests/corpus/benign/dead_anchors_live_refs.md
+++ b/skills/repo-forensics/tests/corpus/benign/dead_anchors_live_refs.md
@@ -1,0 +1,23 @@
+# Dead-anchor benign fixture (live-and-owned references)
+
+This file exists to verify `scan_dead_anchors.py` stays SILENT on anchors that
+are live and owned. Every reference below points at a stable, real target whose
+lifecycle is owner-controlled (avoids third-party CI flakiness). Under the
+dead_anchors LO branch (registry/API 200, registered domain) it must produce
+ZERO findings.
+
+## Stable GitHub references
+
+Project source lives at github.com/alexgreensh/repo-forensics and can also be
+referenced as github:alexgreensh/repo-forensics for the shorthand install form.
+
+## Live package references
+
+Install the JavaScript helper with `npm install lodash` and the Python HTTP
+client with `pip install requests`. Both are long-lived, widely used packages.
+
+## Live documentation domains
+
+See the docs at https://docs.python.org/3/library/os.html and the registry at
+https://pypi.org/project/requests for details. These are safe-allowlisted and
+are never probed.

--- a/skills/repo-forensics/tests/corpus/budgets.json
+++ b/skills/repo-forensics/tests/corpus/budgets.json
@@ -79,5 +79,13 @@
     "medium": 0,
     "low": 0,
     "_comment": "Multi-stage Dockerfile with ARG for non-sensitive build metadata (APP_VERSION, BUILD_DATE, GIT_COMMIT) and ENV for non-sensitive runtime config (APP_ENV, PORT, PYTHONDONTWRITEBYTECODE). No passwords, keys, or tokens in ARG/ENV. Verifies the Dockerfile scanner does not fire on normal build/runtime parameters."
+  },
+
+  "benign/dead_anchors_live_refs.md": {
+    "critical": 0,
+    "high": 0,
+    "medium": 0,
+    "low": 0,
+    "_comment": "Dead-anchor fixture: live GitHub owner/repo + github: shorthand, live npm (lodash) / PyPI (requests) install commands, safe-allowlisted docs domains. The committed-corpus gate runs the per-file scan_file scanners (secrets/sast/skill_threats/…) on it and they must stay at zero. dead_anchors itself is a scan_repo scanner (not in _SCAN_FILE_MODULES) so its LO-branch silence is asserted separately in test_scan_dead_anchors.py (test_benign_corpus_all_lo_zero_findings) with the network mocked to 200/registered — never a real request in CI."
   }
 }

--- a/skills/repo-forensics/tests/test_dead_anchors_extract.py
+++ b/skills/repo-forensics/tests/test_dead_anchors_extract.py
@@ -1,0 +1,211 @@
+"""Tests for dead_anchors_extract.py — U1 anchor extraction (zero network)."""
+
+import os
+
+import pytest
+
+import dead_anchors_extract as extract
+import rule_loader
+
+
+def _write(tmp_path, name, body):
+    p = tmp_path / name
+    p.write_text(body, encoding="utf-8")
+    return tmp_path
+
+
+def _anchors(tmp_path):
+    return extract.extract_anchors(str(tmp_path))
+
+
+def _by_type(anchors, t):
+    return [a for a in anchors if a.type == t]
+
+
+# --- GitHub extraction -------------------------------------------------------
+
+def test_github_url_extracts_owner_repo(tmp_path):
+    _write(tmp_path, "SKILL.md", "source at github.com/torvalds/linux here")
+    gh = _by_type(_anchors(tmp_path), "github")
+    assert len(gh) == 1 and gh[0].owner == "torvalds" and gh[0].repo == "linux"
+
+
+def test_github_shorthand_extracts_same_shape(tmp_path):
+    _write(tmp_path, "SKILL.md", "install github:hexiaochun/seedance2-api now")
+    gh = _by_type(_anchors(tmp_path), "github")
+    assert len(gh) == 1 and gh[0].target == "hexiaochun/seedance2-api"
+
+
+def test_reserved_word_owner_excluded(tmp_path):
+    _write(tmp_path, "SKILL.md", "visit github.com/about for info")
+    assert _by_type(_anchors(tmp_path), "github") == []
+
+
+def test_npx_skills_does_not_double_fire(tmp_path):
+    # Not an install verb, not github: prefixed -> extracts NOTHING.
+    _write(tmp_path, "SKILL.md", "run npx skills hexiaochun/seedance2-api")
+    anchors = _anchors(tmp_path)
+    assert _by_type(anchors, "github") == []
+    assert _by_type(anchors, "package") == []
+
+
+def test_github_dedup_single_anchor(tmp_path):
+    _write(tmp_path, "SKILL.md",
+           "github.com/x/y\nlater again https://github.com/x/y done")
+    assert len(_by_type(_anchors(tmp_path), "github")) == 1
+
+
+# --- package extraction ------------------------------------------------------
+
+def test_pip_install_strips_version(tmp_path):
+    _write(tmp_path, "SKILL.md", "pip install requests==2.31.0")
+    pk = _by_type(_anchors(tmp_path), "package")
+    assert len(pk) == 1 and pk[0].ecosystem == "PyPI"
+    assert pk[0].target == "PyPI:requests"
+
+
+def test_npm_install_strips_flag_and_specifier(tmp_path):
+    _write(tmp_path, "SKILL.md", "npm install --save lodash@^4.17.0")
+    pk = _by_type(_anchors(tmp_path), "package")
+    assert len(pk) == 1 and pk[0].target == "npm:lodash"
+
+
+def test_gem_cargo_not_probed_in_p0(tmp_path):
+    _write(tmp_path, "SKILL.md", "gem install rails\ncargo install ripgrep")
+    # ecosystem=None entries are dropped from the returned set (not probed).
+    assert _by_type(_anchors(tmp_path), "package") == []
+
+
+def test_no_package_from_prose(tmp_path):
+    _write(tmp_path, "SKILL.md", "we install the software manually")
+    assert _by_type(_anchors(tmp_path), "package") == []
+
+
+# --- domain / cloud extraction ----------------------------------------------
+
+def test_bare_cloud_suffix_without_subdomain_excluded(tmp_path):
+    _write(tmp_path, "SKILL.md", "hosted somewhere on https://vercel.app today")
+    a = _anchors(tmp_path)
+    assert _by_type(a, "cloud") == []
+    # And it is not RDAP-probed as a bare domain either.
+    assert _by_type(a, "domain") == []
+
+
+def test_cloud_subdomain_flagged_free_tier(tmp_path):
+    _write(tmp_path, "SKILL.md", "app at https://myapp.vercel.app/home")
+    cl = _by_type(_anchors(tmp_path), "cloud")
+    assert len(cl) == 1 and cl[0].suffix == "vercel.app" and cl[0].is_free_tier
+
+
+def test_safe_domain_allowlist_skipped(tmp_path):
+    _write(tmp_path, "SKILL.md", "docs https://docs.python.org/3/library/os.html")
+    assert _by_type(_anchors(tmp_path), "domain") == []
+
+
+def test_compound_tld_reduction(tmp_path):
+    _write(tmp_path, "SKILL.md", "link https://sub.example.co.uk/x page")
+    dm = _by_type(_anchors(tmp_path), "domain")
+    assert len(dm) == 1 and dm[0].target == "example.co.uk"
+
+
+def test_plain_domain_reduction(tmp_path):
+    _write(tmp_path, "SKILL.md", "link https://a.b.example.com/x page")
+    dm = _by_type(_anchors(tmp_path), "domain")
+    assert len(dm) == 1 and dm[0].target == "example.com"
+
+
+# --- discovery / robustness --------------------------------------------------
+
+def test_reads_multiple_seed_files(tmp_path):
+    _write(tmp_path, "SKILL.md", "github.com/a/b")
+    (tmp_path / "AGENTS.md").write_text("pip install flask", encoding="utf-8")
+    a = _anchors(tmp_path)
+    assert _by_type(a, "github") and _by_type(a, "package")
+
+
+def test_line_and_file_tracked(tmp_path):
+    _write(tmp_path, "SKILL.md", "intro\nsee github.com/a/b\n")
+    gh = _by_type(_anchors(tmp_path), "github")[0]
+    assert gh.file == "SKILL.md" and gh.line == 2
+
+
+def test_empty_repo_no_anchors(tmp_path):
+    (tmp_path / "main.py").write_text("print('hi')", encoding="utf-8")
+    assert _anchors(tmp_path) == []
+
+
+# --- rulepack self-test ------------------------------------------------------
+
+def test_rulepack_self_tests_pass():
+    pack = rule_loader.load_pack("dead_anchors")
+    assert pack is not None
+    results = rule_loader.self_test_pack(pack)
+    failed = [r for r in results if not r.passed]
+    assert not failed, f"pack self-test failures: {failed}"
+    assert len(pack.all_rules) == 8
+
+
+# --- torture-room regressions ------------------------------------------------
+
+def test_fifo_seed_file_is_skipped_no_hang(tmp_path):
+    # A FIFO named SKILL.md (shippable inside a malicious tar/repo) must be
+    # skipped, never opened for read — otherwise extract_anchors blocks forever
+    # (python-redos F1). Hard watchdog: the call must complete well under 5s.
+    import os
+    import threading
+    if not hasattr(os, "mkfifo"):
+        pytest.skip("mkfifo unavailable on this platform")
+    os.mkfifo(str(tmp_path / "SKILL.md"))
+    (tmp_path / "AGENTS.md").write_text("github.com/live/repo", encoding="utf-8")
+    # Preload the pack in the main thread (rule_loader's SIGALRM ReDoS guard only
+    # works in the main thread); the watchdog thread just runs extraction.
+    pack = rule_loader.load_pack("dead_anchors")
+    result = {}
+
+    def _run():
+        result["anchors"] = extract.extract_anchors(str(tmp_path), pack=pack)
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    t.join(5.0)
+    assert not t.is_alive(), "extract_anchors hung on a FIFO seed file"
+    # The FIFO is skipped; the real AGENTS.md is still processed.
+    assert _by_type(result["anchors"], "github")
+
+
+def test_malformed_pack_non_keyword_rule_no_crash(tmp_path):
+    # A pack whose keyword id (DA-CL-001) is tampered into a non-keyword type
+    # (rule.values is then None) must degrade to a no-op, never set(None) crash
+    # (python-redos F2 / never-hard-fail).
+    class _FakeRule:
+        def __init__(self, rid, rtype, regex=None, values=None):
+            self.id = rid
+            self.type = rtype
+            self.regex = regex
+            self.values = values
+
+    import re as _re
+
+    class _FakePack:
+        all_rules = [
+            _FakeRule("DA-GH-001", "regex", regex=_re.compile(r"github\.com/(\w+)/(\w+)")),
+            _FakeRule("DA-CL-001", "regex", regex=_re.compile(r"x")),  # tampered: no .values
+        ]
+
+    _write(tmp_path, "SKILL.md", "github.com/a/b")
+    # Must not raise even though DA-CL-001 has values=None.
+    anchors = extract.extract_anchors(str(tmp_path), pack=_FakePack())
+    assert isinstance(anchors, list)
+
+
+def test_github_case_variants_dedup_single_anchor(tmp_path):
+    _write(tmp_path, "SKILL.md",
+           "github.com/Torvalds/Linux\ngithub.com/torvalds/linux\n"
+           "github.com/TORVALDS/LINUX")
+    assert len(_by_type(_anchors(tmp_path), "github")) == 1
+
+
+def test_pypi_separator_variants_dedup_single_anchor(tmp_path):
+    _write(tmp_path, "SKILL.md",
+           "pip install My_Package\npip install my-package\npip install my.package")
+    assert len(_by_type(_anchors(tmp_path), "package")) == 1

--- a/skills/repo-forensics/tests/test_dead_anchors_probe.py
+++ b/skills/repo-forensics/tests/test_dead_anchors_probe.py
@@ -1,0 +1,467 @@
+"""Tests for dead_anchors_probe.py — U2 network claimability layer.
+
+EVERY network call is monkeypatched: vuln_feed's urllib.request.urlopen (the one
+real HTTPS chokepoint, reached through vuln_feed._https_fetch) and the probe
+module's socket.gethostbyname. NO test ever performs a real HTTP request or DNS
+lookup. A module-level call counter backs the "zero real network" assertions,
+the budget/ceiling caps, the circuit breaker, and the no-retry guarantee.
+"""
+
+import io
+import socket
+import urllib.error
+
+import pytest
+
+import dead_anchors_probe as probe
+import vuln_feed
+
+
+# --- network doubles ---------------------------------------------------------
+
+class _FakeResp:
+    def __init__(self, body):
+        self._body = body if isinstance(body, bytes) else body.encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self, n):
+        return self._body[:n]
+
+
+class _Net:
+    """Routes a request URL to a 2-tuple (code, body), a 3-tuple
+    (code, body, final_url) — final_url models the URL a redirect chain actually
+    landed on, used to test rdap.org registry-vs-bootstrap 404 discrimination —
+    or an Exception. Counts every urlopen invocation."""
+
+    def __init__(self, router):
+        self.router = router
+        self.calls = []
+
+    def urlopen(self, req, timeout=None):
+        url = getattr(req, "full_url", req)
+        self.calls.append(url)
+        outcome = self.router(url)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        if len(outcome) == 3:
+            code, body, final_url = outcome
+        else:
+            code, body = outcome
+            final_url = url
+        if code == 200:
+            return _FakeResp(body)
+        fp = io.BytesIO(body.encode("utf-8") if isinstance(body, str) else body)
+        raise urllib.error.HTTPError(final_url, code, "err", {}, fp)
+
+
+def _install(monkeypatch, router):
+    net = _Net(router)
+    monkeypatch.setattr(vuln_feed.urllib.request, "urlopen", net.urlopen)
+    # Route the scanner's no-redirect / bounded-redirect openers back through the
+    # single mocked chokepoint (see probe._DirectOpener). Production uses the
+    # real openers; here every probe still hits the mock, never real network.
+    monkeypatch.setattr(probe, "_no_redirect_opener", lambda: probe._DirectOpener())
+    monkeypatch.setattr(probe, "_bounded_redirect_opener", lambda: probe._DirectOpener())
+    # getaddrinfo defaults to "resolves to a public IP" unless a test overrides.
+    monkeypatch.setattr(probe.socket, "getaddrinfo", _fake_getaddrinfo("1.2.3.4"))
+    return net
+
+
+def _fake_getaddrinfo(ip):
+    fam = socket.AF_INET6 if ":" in ip else socket.AF_INET
+    return lambda host, port, *a, **k: [
+        (fam, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, port))
+    ]
+
+
+def _nxdomain_getaddrinfo(host, port, *a, **k):
+    raise socket.gaierror(socket.EAI_NONAME, "Name or service not known")
+
+
+def _ctx(tmp_path, offline=False, github_token=None):
+    return probe.ProbeContext(offline=offline, cache_dir=str(tmp_path),
+                              github_token=github_token)
+
+
+_FPS = {
+    "vercel.app": [{"s": "DEPLOYMENT_NOT_FOUND", "confidence": 0.8, "strict": True}],
+    "pages.dev": [{"s": "project not found", "confidence": 0.7}],  # non-strict
+}
+
+
+# --- positive CC verdicts ----------------------------------------------------
+
+def test_github_user_404_is_cc(tmp_path, monkeypatch):
+    _install(monkeypatch, lambda u: (404, ""))
+    verdict, _ = probe.probe_github_user("ghostowner", _ctx(tmp_path))
+    assert verdict == "CC"
+
+
+def test_npm_and_pypi_404_are_cc(tmp_path, monkeypatch):
+    _install(monkeypatch, lambda u: (404, ""))
+    assert probe.probe_npm("phantom-pkg", _ctx(tmp_path))[0] == "CC"
+    assert probe.probe_pypi("phantom-pkg", _ctx(tmp_path))[0] == "CC"
+
+
+def test_rdap_404_is_cc(tmp_path, monkeypatch):
+    # A registry RDAP server (reached after the rdap.org bootstrap redirect)
+    # returning 404 means the domain genuinely does not exist => CC.
+    _install(monkeypatch, lambda u: (
+        404, "", "https://rdap.verisign.com/com/v1/domain/expired-example.com"))
+    assert probe.probe_domain_rdap("expired-example.com", _ctx(tmp_path))[0] == "CC"
+
+
+def test_rdap_bootstrap_gap_404_is_nc(tmp_path, monkeypatch):
+    # A bare 404 straight from rdap.org (no redirect happened -> final host is
+    # still rdap.org) means it could not bootstrap a server for this TLD; that is
+    # ambiguous and must NOT fire a false CRITICAL on a possibly-live domain.
+    _install(monkeypatch, lambda u: (404, ""))  # final_url defaults to rdap.org
+    assert probe.probe_domain_rdap("some-cctld-domain.zz", _ctx(tmp_path))[0] == "NC"
+
+
+def test_cloud_nxdomain_is_cc(tmp_path, monkeypatch):
+    _install(monkeypatch, lambda u: (200, "ok"))
+    monkeypatch.setattr(probe.socket, "getaddrinfo", _nxdomain_getaddrinfo)
+    verdict, extra = probe.probe_cloud_subdomain("dead.vercel.app", "vercel.app",
+                                                 _ctx(tmp_path), fingerprints=_FPS)
+    assert verdict == "CC" and extra.get("reason") == "nxdomain"
+
+
+def test_cloud_ipv6_only_is_not_nxdomain(tmp_path, monkeypatch):
+    # AAAA-only host resolves fine via getaddrinfo -> must NOT be a false CC
+    # (security-sentinel F3: gethostbyname is IPv4-only and would misread it).
+    _install(monkeypatch, lambda u: (200, "<html>live app</html>"))
+    monkeypatch.setattr(probe.socket, "getaddrinfo",
+                        _fake_getaddrinfo("2606:4700::1111"))
+    verdict, _ = probe.probe_cloud_subdomain("live.vercel.app", "vercel.app",
+                                             _ctx(tmp_path), fingerprints=_FPS)
+    assert verdict == "LO"
+
+
+def test_cloud_internal_ip_not_fetched(tmp_path, monkeypatch):
+    # A subdomain that resolves into a private/metadata range is never fetched
+    # (structural SSRF backstop, security-sentinel F1/F4) -> NC, no HTTP call.
+    net = _install(monkeypatch, lambda u: (200, "DEPLOYMENT_NOT_FOUND"))
+    monkeypatch.setattr(probe.socket, "getaddrinfo",
+                        _fake_getaddrinfo("169.254.169.254"))
+    verdict, _ = probe.probe_cloud_subdomain("evil.vercel.app", "vercel.app",
+                                             _ctx(tmp_path), fingerprints=_FPS)
+    assert verdict == "NC"
+    assert net.calls == []  # no HTTP fetch to the internal address
+
+
+def test_cloud_fingerprint_vercel_is_cc(tmp_path, monkeypatch):
+    _install(monkeypatch, lambda u: (200, "<h1>DEPLOYMENT_NOT_FOUND</h1>"))
+    verdict, extra = probe.probe_cloud_subdomain("gone.vercel.app", "vercel.app",
+                                                 _ctx(tmp_path), fingerprints=_FPS)
+    assert verdict == "CC" and extra.get("reason") == "fingerprint"
+
+
+def test_cloud_non_strict_fingerprint_is_lo(tmp_path, monkeypatch):
+    # pages.dev 'project not found' is a NON-strict entry now (generic phrase
+    # that collides with live apps) -> must never fire CC on a resolving host.
+    _install(monkeypatch, lambda u: (200, "project not found"))
+    verdict, _ = probe.probe_cloud_subdomain("x.pages.dev", "pages.dev",
+                                             _ctx(tmp_path), fingerprints=_FPS)
+    assert verdict == "LO"
+
+
+def test_cloud_resolving_404_no_fingerprint_is_lo(tmp_path, monkeypatch):
+    # Resolving host + bare 404 + no strict fingerprint -> LO (silent), NEVER a
+    # false CRITICAL (error-soundness F2). netlify has no fingerprint at all.
+    _install(monkeypatch, lambda u: (404, "Page not found"))
+    verdict, _ = probe.probe_cloud_subdomain("app.netlify.app", "netlify.app",
+                                             _ctx(tmp_path), fingerprints=_FPS)
+    assert verdict == "LO"
+
+
+def test_cloud_fingerprint_on_404_body_is_cc(tmp_path, monkeypatch):
+    # A strict provider token present in a 404 error body still fires CC — the
+    # body must be captured on the non-200 path (error-soundness F2 fix).
+    _install(monkeypatch, lambda u: (404, "<h1>DEPLOYMENT_NOT_FOUND</h1>"))
+    verdict, extra = probe.probe_cloud_subdomain("gone.vercel.app", "vercel.app",
+                                                 _ctx(tmp_path), fingerprints=_FPS)
+    assert verdict == "CC" and extra.get("reason") == "fingerprint"
+
+
+def test_cloud_generic_netlify_is_lo(tmp_path, monkeypatch):
+    # netlify.app is deliberately NOT in the fingerprint map -> generic 404 copy
+    # is never trusted -> LO (spec §4 "do not guess").
+    _install(monkeypatch, lambda u: (200, "Page not found - back to home"))
+    verdict, _ = probe.probe_cloud_subdomain("app.netlify.app", "netlify.app",
+                                             _ctx(tmp_path), fingerprints=_FPS)
+    assert verdict == "LO"
+
+
+# --- negative / LO verdicts --------------------------------------------------
+
+def test_all_types_200_are_lo(tmp_path, monkeypatch):
+    _install(monkeypatch, lambda u: (200, '{"login":"x","public_repos":50}'))
+    assert probe.probe_github_user("torvalds", _ctx(tmp_path))[0] == "LO"
+    assert probe.probe_npm("lodash", _ctx(tmp_path))[0] == "LO"
+    assert probe.probe_pypi("requests", _ctx(tmp_path))[0] == "LO"
+    assert probe.probe_domain_rdap("python.org", _ctx(tmp_path))[0] == "LO"
+
+
+@pytest.mark.parametrize("code", [403, 429, 500, 502, 418])
+def test_error_codes_are_nc_no_raise(tmp_path, monkeypatch, code):
+    _install(monkeypatch, lambda u: (code, ""))
+    # None of these may raise; all degrade to NC.
+    assert probe.probe_github_user("someone", _ctx(tmp_path))[0] == "NC"
+    assert probe.probe_npm("pkg", _ctx(tmp_path))[0] == "NC"
+
+
+@pytest.mark.parametrize("exc", [
+    urllib.error.URLError("boom"),
+    socket.timeout("slow"),
+    TimeoutError("slow"),
+    OSError("io"),
+])
+def test_network_exceptions_are_nc_no_raise(tmp_path, monkeypatch, exc):
+    _install(monkeypatch, lambda u: exc)
+    assert probe.probe_github_user("someone", _ctx(tmp_path))[0] == "NC"
+    assert probe.probe_domain_rdap("example.com", _ctx(tmp_path))[0] == "NC"
+
+
+def test_rdap_past_expiration_sets_flag(tmp_path, monkeypatch):
+    body = '{"events":[{"eventAction":"expiration","eventDate":"2000-01-01T00:00:00Z"}]}'
+    _install(monkeypatch, lambda u: (200, body))
+    verdict, extra = probe.probe_domain_rdap("lapsing.com", _ctx(tmp_path))
+    assert verdict == "LO" and extra and extra.get("imminent_expiry") is True
+
+
+# --- offline: cheapest path, zero sockets ------------------------------------
+
+def test_offline_all_probes_nc_zero_network(tmp_path, monkeypatch):
+    net = _install(monkeypatch, lambda u: (404, ""))
+
+    def _boom(*a, **k):
+        raise AssertionError("DNS must not be resolved offline")
+
+    monkeypatch.setattr(probe.socket, "getaddrinfo", _boom)
+    ctx = _ctx(tmp_path, offline=True)
+    assert probe.probe_github_user("x", ctx)[0] == "NC"
+    assert probe.probe_github_repo("x", "y", ctx)[0] == "NC"
+    assert probe.probe_npm("x", ctx)[0] == "NC"
+    assert probe.probe_pypi("x", ctx)[0] == "NC"
+    assert probe.probe_domain_rdap("x.com", ctx)[0] == "NC"
+    assert probe.probe_cloud_subdomain("a.vercel.app", "vercel.app", ctx,
+                                       fingerprints=_FPS)[0] == "NC"
+    assert net.calls == []  # zero urlopen calls
+
+
+# --- budget / ceiling / deadline (loop-safety) -------------------------------
+
+def test_github_budget_exhausted_no_urlopen(tmp_path, monkeypatch):
+    net = _install(monkeypatch, lambda u: (404, ""))
+    ctx = _ctx(tmp_path)
+    ctx.budget = probe._ProbeBudget(0, 50)  # GH cap exhausted
+    verdict, _ = probe.probe_github_user("x", ctx)
+    assert verdict == "NC"
+    assert net.calls == []  # never issued a request
+
+
+def test_total_ceiling_caps_probes(tmp_path, monkeypatch):
+    net = _install(monkeypatch, lambda u: (200, "{}"))
+    ctx = _ctx(tmp_path)
+    ctx.budget = probe._ProbeBudget(100, 50)  # generous GH, total ceiling 50
+    attempted = 0
+    for i in range(60):
+        probe.probe_npm(f"pkg-{i}", ctx)
+        attempted += 1
+    assert len(net.calls) <= 50
+    assert attempted == 60  # all called, but ceiling capped real requests
+
+
+def test_global_deadline_stops_probes(tmp_path, monkeypatch):
+    net = _install(monkeypatch, lambda u: (200, "{}"))
+    monkeypatch.setattr(probe, "NETWORK_DEADLINE_SEC", 0.0)
+    ctx = _ctx(tmp_path)  # deadline already expired at construction
+    assert probe.probe_github_user("x", ctx)[0] == "NC"
+    assert probe.probe_npm("y", ctx)[0] == "NC"
+    assert net.calls == []
+
+
+# --- circuit breaker + no-retry ----------------------------------------------
+
+def test_circuit_breaker_trips_on_429(tmp_path, monkeypatch):
+    net = _install(monkeypatch, lambda u: (429, ""))
+    ctx = _ctx(tmp_path)
+    assert probe.probe_github_user("owner1", ctx)[0] == "NC"  # trips breaker
+    # A DIFFERENT owner on the SAME host must not touch the network.
+    calls_before = len(net.calls)
+    assert probe.probe_github_user("owner2", ctx)[0] == "NC"
+    assert len(net.calls) == calls_before  # zero further api.github.com calls
+
+
+def test_circuit_breaker_is_per_host(tmp_path, monkeypatch):
+    net = _install(monkeypatch,
+                   lambda u: (429, "") if "github" in u else (404, ""))
+    ctx = _ctx(tmp_path)
+    assert probe.probe_github_user("owner1", ctx)[0] == "NC"  # GH breaker trips
+    # npm host is unaffected -> still probes and returns CC on 404.
+    assert probe.probe_npm("phantom", ctx)[0] == "CC"
+
+
+def test_no_retry_single_attempt(tmp_path, monkeypatch):
+    net = _install(monkeypatch, lambda u: (429, ""))
+    ctx = _ctx(tmp_path)
+    probe.probe_github_user("owner1", ctx)
+    # Exactly one urlopen for that owner; the breaker prevents OTHERS, and there
+    # is no retry of the original anchor.
+    assert net.calls.count("https://api.github.com/users/owner1") == 1
+
+
+# --- 24h atomic result cache -------------------------------------------------
+
+def test_cache_hit_avoids_network(tmp_path, monkeypatch):
+    net = _install(monkeypatch, lambda u: (404, ""))
+    ctx = _ctx(tmp_path)
+    # Pre-populate a fresh LO verdict for the exact key.
+    ctx.cache_put("gh_user::torvalds", "LO", {"public_repos": 99})
+    net.calls.clear()
+    verdict, meta = probe.probe_github_user("torvalds", ctx)
+    assert verdict == "LO"
+    assert net.calls == []  # served from cache, zero network
+
+
+def test_cache_miss_expired_reprobes(tmp_path, monkeypatch):
+    net = _install(monkeypatch, lambda u: (200, "{}"))
+    ctx = _ctx(tmp_path)
+    # Write a stale (>24h) entry by hand.
+    import time
+    path = ctx._cache_path("npm::lodash")
+    vuln_feed._atomic_write(path, {"_cached_at": time.time() - 90000,
+                                   "verdict": "CC", "extra": {}})
+    verdict, _ = probe.probe_npm("lodash", ctx)
+    assert verdict == "LO"  # re-probed, not the stale CC
+    assert len(net.calls) == 1
+
+
+def test_malformed_cache_tolerated(tmp_path, monkeypatch):
+    net = _install(monkeypatch, lambda u: (404, ""))
+    ctx = _ctx(tmp_path)
+    path = ctx._cache_path("npm::brokenpkg")
+    import os
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write("{ this is not valid json")
+    # Must fall through to a normal probe, no exception.
+    verdict, _ = probe.probe_npm("brokenpkg", ctx)
+    assert verdict == "CC"
+
+
+def test_cache_write_uses_atomic_replace(tmp_path, monkeypatch):
+    # Simulate two racing writes for the same key: both complete, final file is
+    # valid JSON (never torn) — os.replace is the mechanism (via _atomic_write).
+    import os
+    import json as _json
+    _install(monkeypatch, lambda u: (200, "{}"))
+    ctx = _ctx(tmp_path)
+    ctx.cache_put("npm::race", "LO", {"n": 1})
+    ctx.cache_put("npm::race", "LO", {"n": 2})
+    path = ctx._cache_path("npm::race")
+    with open(path) as f:
+        data = _json.load(f)  # parses cleanly => not torn
+    assert data["verdict"] == "LO"
+
+
+def test_nc_is_never_cached(tmp_path, monkeypatch):
+    _install(monkeypatch, lambda u: (403, ""))
+    ctx = _ctx(tmp_path)
+    probe.probe_npm("throttled", ctx)
+    import os
+    path = ctx._cache_path("npm::throttled")
+    assert not os.path.exists(path)  # transient NC not persisted
+
+
+# --- assert the suite itself never hit real network --------------------------
+
+def test_no_real_network_sentinel(tmp_path, monkeypatch):
+    # If any probe reached real urlopen, that means the monkeypatch missed. Prove
+    # the chokepoint is vuln_feed._https_fetch -> urllib.request.urlopen (routed
+    # through the no-redirect opener, seamed via _DirectOpener in tests). A fresh
+    # tmp cache dir guarantees a real network attempt (no cache short-circuit).
+    hit = {"n": 0}
+    monkeypatch.setattr(probe, "_no_redirect_opener", lambda: probe._DirectOpener())
+    monkeypatch.setattr(vuln_feed.urllib.request, "urlopen",
+                        lambda *a, **k: hit.__setitem__("n", hit["n"] + 1) or (_ for _ in ()).throw(urllib.error.URLError("blocked")))
+    ctx = probe.ProbeContext(offline=False, cache_dir=str(tmp_path))
+    probe.probe_npm("anything", ctx)
+    assert hit["n"] == 1  # went through the mocked chokepoint, not the real net
+
+
+# --- redirect / SSRF hardening -----------------------------------------------
+
+def test_no_redirect_handler_refuses_all_redirects():
+    # The production no-redirect handler never follows a 3xx (returns None so
+    # urllib raises the redirect as its own HTTPError instead of auto-fetching).
+    h = probe._NoRedirectHandler()
+    assert h.redirect_request(None, None, 302, "Found", {},
+                              "http://169.254.169.254/latest/meta-data/") is None
+
+
+def test_bounded_redirect_rejects_http_scheme():
+    # RDAP's bounded opener refuses a downgrade to http:// (and only follows
+    # https hops to non-internal hosts).
+    h = probe._BoundedRedirectHandler()
+    assert h.redirect_request(None, None, 302, "Found", {},
+                              "http://rdap.verisign.com/x") is None
+
+
+def test_3xx_not_followed_single_call_breaker_intact(tmp_path, monkeypatch):
+    # A 3xx from an anchor host is treated as COULDN'T-CHECK, NOT auto-followed:
+    # exactly one call, no extra request to the Location, breaker untouched.
+    net = _install(monkeypatch, lambda u: (
+        302, "", "http://169.254.169.254/latest/meta-data/"))
+    ctx = _ctx(tmp_path)
+    verdict, _ = probe.probe_github_user("someowner", ctx)
+    assert verdict == "NC"
+    assert len(net.calls) == 1  # no follow to the redirect target
+    assert not ctx.breaker.is_tripped(probe._HOST_GITHUB)
+
+
+# --- name normalization (no phantom on brand-cased / separator-variant) -------
+
+def test_npm_brand_case_resolves_live_not_phantom(tmp_path, monkeypatch):
+    # 'React' must probe the canonical 'react' (live) -> LO, never a phantom CC.
+    def router(u):
+        return (200, "{}") if u.endswith("/react") else (404, "")
+    net = _install(monkeypatch, router)
+    assert probe.probe_npm("React", _ctx(tmp_path))[0] == "LO"
+
+
+def test_pypi_pep503_normalization_resolves_live(tmp_path, monkeypatch):
+    # 'My_Package' must probe canonical 'my-package' -> LO, never a phantom CC.
+    def router(u):
+        return (200, "{}") if "/my-package/" in u else (404, "")
+    _install(monkeypatch, router)
+    assert probe.probe_pypi("My_Package", _ctx(tmp_path))[0] == "LO"
+
+
+def test_github_token_does_not_inflate_budget(tmp_path, monkeypatch):
+    # A GITHUB_TOKEN must NOT raise the call cap (it is never attached to a
+    # request), so the budget stays at the unauthenticated ceiling.
+    _install(monkeypatch, lambda u: (200, "{}"))
+    ctx = _ctx(tmp_path, github_token="ghp_dummy")
+    assert ctx.budget.gh_remaining == probe.GITHUB_CALL_CAP
+
+
+def test_cache_symlinked_dir_not_written(tmp_path, monkeypatch):
+    # If the cache dir is a symlink, no verdict is written through it
+    # (cache-poisoning backstop, security-sentinel F6).
+    import os
+    real = tmp_path / "real"
+    real.mkdir()
+    link = tmp_path / "link"
+    os.symlink(str(real), str(link))
+    _install(monkeypatch, lambda u: (404, ""))
+    ctx = probe.ProbeContext(offline=False, cache_dir=str(link))
+    ctx.cache_put("npm::x", "CC", None)
+    assert os.listdir(str(real)) == []  # nothing written through the symlink

--- a/skills/repo-forensics/tests/test_non_breaking_contract.py
+++ b/skills/repo-forensics/tests/test_non_breaking_contract.py
@@ -75,6 +75,10 @@ EXPECTED_BASE_SCANNER_NAMES = {
     # split-stream reassembly and artifact provenance are standalone scanners.
     "splitstream",
     "provenance",
+    # 2026-07 Skilljacking gap (AIR research): external-anchor claimability
+    # (repojacking / phantom package / expired domain / dangling cloud slug).
+    # Standalone algorithmic scanner, network-touching, silent-by-default.
+    "dead_anchors",
 }
 
 # Synthetic scanner entries injected by aggregate_json.py AFTER the real

--- a/skills/repo-forensics/tests/test_scan_dead_anchors.py
+++ b/skills/repo-forensics/tests/test_scan_dead_anchors.py
@@ -1,0 +1,303 @@
+"""Tests for scan_dead_anchors.py — U3 end-to-end orchestration.
+
+All network monkeypatched (vuln_feed urlopen chokepoint + probe.socket). The
+full pipeline (extract -> probe -> classify -> Finding) is exercised per anchor
+type, plus the never-hard-fail / offline / budget contracts.
+"""
+
+import io
+import socket
+import urllib.error
+
+import pytest
+
+import scan_dead_anchors as scanner
+import dead_anchors_probe as probe
+import vuln_feed
+
+
+class _FakeResp:
+    def __init__(self, body):
+        self._body = body if isinstance(body, bytes) else body.encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self, n):
+        return self._body[:n]
+
+
+class _Net:
+    def __init__(self, router):
+        self.router = router
+        self.calls = []
+
+    def urlopen(self, req, timeout=None):
+        url = getattr(req, "full_url", req)
+        self.calls.append(url)
+        outcome = self.router(url)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        if len(outcome) == 3:
+            code, body, final_url = outcome
+        else:
+            code, body = outcome
+            final_url = url
+        if code == 200:
+            return _FakeResp(body)
+        fp = io.BytesIO(body.encode("utf-8") if isinstance(body, str) else body)
+        raise urllib.error.HTTPError(final_url, code, "err", {}, fp)
+
+
+def _fake_getaddrinfo(ip):
+    return lambda host, port, *a, **k: [
+        (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, port))
+    ]
+
+
+def _rdap_registry_404(url):
+    """Model rdap.org bootstrap: a domain 404 arrives from a delegated registry
+    host (redirect landed off rdap.org) -> genuine 'not registered'."""
+    if "rdap.org" in url:
+        return (404, "", "https://rdap.verisign.com/com/v1" + url.split("rdap.org", 1)[1])
+    return (404, "")
+
+
+def _install(monkeypatch, router, resolves=True):
+    net = _Net(router)
+    monkeypatch.setattr(vuln_feed.urllib.request, "urlopen", net.urlopen)
+    monkeypatch.setattr(probe, "_no_redirect_opener", lambda: probe._DirectOpener())
+    monkeypatch.setattr(probe, "_bounded_redirect_opener", lambda: probe._DirectOpener())
+    if resolves:
+        monkeypatch.setattr(probe.socket, "getaddrinfo", _fake_getaddrinfo("1.2.3.4"))
+    return net
+
+
+def _use_tmp_cache(monkeypatch, tmp_path):
+    monkeypatch.setattr(probe, "_default_cache_dir", lambda: str(tmp_path / "cache"))
+
+
+def _skill(tmp_path, body):
+    (tmp_path / "SKILL.md").write_text(body, encoding="utf-8")
+    return str(tmp_path)
+
+
+# --- positive teeth per anchor type ------------------------------------------
+
+def test_github_user_404_one_critical(tmp_path, monkeypatch):
+    _use_tmp_cache(monkeypatch, tmp_path)
+    _install(monkeypatch, lambda u: (404, ""))
+    repo = _skill(tmp_path, "source github.com/ghostowner/proj")
+    findings = scanner.scan_repo(repo)
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.severity == "critical" and f.category == "dead-anchor"
+    assert "ghostowner" in f.title
+
+
+def test_github_repo_404_under_live_owner_one_medium(tmp_path, monkeypatch):
+    _use_tmp_cache(monkeypatch, tmp_path)
+
+    def router(u):
+        if u.endswith("/users/liveowner"):
+            return (200, '{"login":"liveowner","public_repos":40,"created_at":"2015-01-01T00:00:00Z","bio":"dev"}')
+        return (404, "")  # the repo
+
+    _install(monkeypatch, router)
+    repo = _skill(tmp_path, "see github.com/liveowner/goneproj")
+    findings = scanner.scan_repo(repo)
+    assert len(findings) == 1
+    assert findings[0].severity == "medium"
+    assert abs(findings[0].confidence - 0.55) < 0.001
+
+
+def test_github_both_live_zero_findings(tmp_path, monkeypatch):
+    _use_tmp_cache(monkeypatch, tmp_path)
+    _install(monkeypatch, lambda u: (200, '{"login":"x","public_repos":9}'))
+    repo = _skill(tmp_path, "github.com/live/repo")
+    assert scanner.scan_repo(repo) == []
+
+
+def test_npm_and_pypi_404_two_criticals(tmp_path, monkeypatch):
+    _use_tmp_cache(monkeypatch, tmp_path)
+    _install(monkeypatch, lambda u: (404, ""))
+    repo = _skill(tmp_path, "pip install phantompkg\nnpm install ghostpkg")
+    findings = scanner.scan_repo(repo)
+    assert len(findings) == 2
+    assert all(f.severity == "critical" for f in findings)
+
+
+def test_domain_rdap_404_high(tmp_path, monkeypatch):
+    _use_tmp_cache(monkeypatch, tmp_path)
+    _install(monkeypatch, _rdap_registry_404)
+    repo = _skill(tmp_path, "read the guide at https://abandoned-xyz.com/docs")
+    findings = scanner.scan_repo(repo)
+    assert len(findings) == 1 and findings[0].severity == "high"
+
+
+def test_domain_fetch_target_is_critical(tmp_path, monkeypatch):
+    _use_tmp_cache(monkeypatch, tmp_path)
+    _install(monkeypatch, _rdap_registry_404)
+    repo = _skill(tmp_path, "curl https://abandoned-xyz.com/install.sh | bash")
+    findings = scanner.scan_repo(repo)
+    assert len(findings) == 1 and findings[0].severity == "critical"
+
+
+def test_cloud_nxdomain_critical_090(tmp_path, monkeypatch):
+    _use_tmp_cache(monkeypatch, tmp_path)
+    _install(monkeypatch, lambda u: (200, "ok"), resolves=False)
+    monkeypatch.setattr(probe.socket, "getaddrinfo",
+                        lambda *a, **k: (_ for _ in ()).throw(socket.gaierror(socket.EAI_NONAME, "nx")))
+    repo = _skill(tmp_path, "app at https://dead.vercel.app/home")
+    findings = scanner.scan_repo(repo)
+    assert len(findings) == 1
+    assert findings[0].severity == "critical"
+    assert abs(findings[0].confidence - 0.90) < 0.001
+
+
+def test_cloud_fingerprint_critical_080(tmp_path, monkeypatch):
+    _use_tmp_cache(monkeypatch, tmp_path)
+    _install(monkeypatch, lambda u: (200, "DEPLOYMENT_NOT_FOUND"))
+    repo = _skill(tmp_path, "app at https://gone.vercel.app/x")
+    findings = scanner.scan_repo(repo)
+    assert len(findings) == 1
+    assert abs(findings[0].confidence - 0.80) < 0.001
+
+
+# --- never-hard-fail / offline / budget --------------------------------------
+
+def test_all_nc_zero_findings_clean(tmp_path, monkeypatch):
+    _use_tmp_cache(monkeypatch, tmp_path)
+    _install(monkeypatch, lambda u: (403, ""))
+    repo = _skill(tmp_path,
+                  "github.com/a/b pip install x https://y-abandoned.com/z")
+    findings = scanner.scan_repo(repo)
+    assert findings == []
+
+
+def test_offline_zero_network_zero_findings(tmp_path, monkeypatch):
+    _use_tmp_cache(monkeypatch, tmp_path)
+    net = _install(monkeypatch, lambda u: (404, ""))
+    monkeypatch.setattr(probe.socket, "getaddrinfo",
+                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("no dns offline")))
+    repo = _skill(tmp_path,
+                  "github.com/a/b pip install x https://app.vercel.app/z")
+    findings = scanner.scan_repo(repo, offline=True)
+    assert findings == []
+    assert net.calls == []
+
+
+def test_github_budget_cap_no_crash(tmp_path, monkeypatch):
+    _use_tmp_cache(monkeypatch, tmp_path)
+    net = _install(monkeypatch, lambda u: (404, ""))
+    lines = "\n".join(f"github.com/owner{i}/repo{i}" for i in range(25))
+    repo = _skill(tmp_path, lines)
+    findings = scanner.scan_repo(repo)
+    # GH cap ~20: at most 20 users probed -> at most 20 CRITICALs, no crash.
+    gh_calls = [c for c in net.calls if "api.github.com/users/" in c]
+    assert len(gh_calls) <= 20
+    assert len(findings) <= 20
+
+
+def test_duplicate_anchor_single_probe(tmp_path, monkeypatch):
+    _use_tmp_cache(monkeypatch, tmp_path)
+    net = _install(monkeypatch, lambda u: (404, ""))
+    body = "\n".join("github.com/dup/repo" for _ in range(50))
+    repo = _skill(tmp_path, body)
+    findings = scanner.scan_repo(repo)
+    user_calls = [c for c in net.calls if c.endswith("/users/dup")]
+    assert len(user_calls) == 1  # deduped: exactly one probe
+    assert len(findings) == 1
+
+
+# --- output shapes -----------------------------------------------------------
+
+def test_json_roundtrip(tmp_path, monkeypatch):
+    _use_tmp_cache(monkeypatch, tmp_path)
+    _install(monkeypatch, lambda u: (404, ""))
+    repo = _skill(tmp_path, "npm install ghostpkg")
+    findings = scanner.scan_repo(repo)
+    d = findings[0].to_dict()
+    for key in ("scanner", "severity", "title", "description", "file", "line",
+                "snippet", "category", "rule_id", "confidence"):
+        assert key in d
+    assert d["scanner"] == "dead_anchors"
+
+
+def test_benign_corpus_all_lo_zero_findings(tmp_path, monkeypatch):
+    # The committed benign dead-anchor fixture, scanned with EVERYTHING mocked to
+    # live-and-owned (200 / registered) -> zero findings. No real network in CI.
+    import os
+    import shutil
+    _use_tmp_cache(monkeypatch, tmp_path)
+    _install(monkeypatch, lambda u: (200, '{"login":"x","public_repos":50}'))
+    src = os.path.join(os.path.dirname(__file__), "corpus", "benign",
+                       "dead_anchors_live_refs.md")
+    dst_dir = tmp_path / "corpusrepo"
+    dst_dir.mkdir()
+    shutil.copy(src, dst_dir / "SKILL.md")
+    assert scanner.scan_repo(str(dst_dir)) == []
+
+
+def test_scan_repo_never_raises_on_garbage(tmp_path, monkeypatch):
+    _use_tmp_cache(monkeypatch, tmp_path)
+    _install(monkeypatch, lambda u: (_ for _ in ()).throw(RuntimeError("boom")))
+    repo = _skill(tmp_path, "github.com/a/b")
+    # Even if a probe internals blew up, scan_repo must degrade to [] not raise.
+    assert scanner.scan_repo(repo) == []
+
+
+# --- regression: torture-room fixes ------------------------------------------
+
+def test_github_case_variants_single_critical(tmp_path, monkeypatch):
+    # 'Torvalds/Linux', 'torvalds/linux', 'TORVALDS/LINUX' are ONE claimable
+    # owner -> exactly one probe and one CRITICAL, not three (code-review F3).
+    _use_tmp_cache(monkeypatch, tmp_path)
+    net = _install(monkeypatch, lambda u: (404, ""))
+    repo = _skill(tmp_path,
+                  "github.com/Torvalds/Linux\ngithub.com/torvalds/linux\n"
+                  "github.com/TORVALDS/LINUX")
+    findings = scanner.scan_repo(repo)
+    assert len(findings) == 1
+    user_calls = [c for c in net.calls if "/users/" in c]
+    assert len(user_calls) == 1
+
+
+def test_npm_install_React_no_phantom(tmp_path, monkeypatch):
+    # 'npm install React' must not produce a phantom CRITICAL for the live
+    # 'react' package (integration F2).
+    _use_tmp_cache(monkeypatch, tmp_path)
+
+    def router(u):
+        return (200, "{}") if u.endswith("/react") else (404, "")
+
+    _install(monkeypatch, router)
+    repo = _skill(tmp_path, "Then run: npm install React and start coding.")
+    assert scanner.scan_repo(repo) == []
+
+
+def test_pages_dev_generic_404_no_finding(tmp_path, monkeypatch):
+    # Real pack: a live pages.dev app that resolves and serves 'project not
+    # found' (its own copy) must NOT be flagged CRITICAL (integration F1). Uses
+    # the REAL fingerprints via scan_repo/_load_fingerprints.
+    _use_tmp_cache(monkeypatch, tmp_path)
+    _install(monkeypatch, lambda u: (200, "Oops - project not found here"))
+    repo = _skill(tmp_path, "app at https://someteam-projects.pages.dev/x")
+    assert scanner.scan_repo(repo) == []
+
+
+def test_malformed_fingerprints_pack_no_crash(tmp_path, monkeypatch):
+    # A valid-JSON-but-non-dict pack file must degrade to a no-op, never crash
+    # (error-soundness F1). Extraction still uses the real rule pack.
+    import json as _json
+    _use_tmp_cache(monkeypatch, tmp_path)
+    _install(monkeypatch, lambda u: (200, '{"login":"x","public_repos":9}'))
+    bad = tmp_path / "bad_pack.json"
+    bad.write_text(_json.dumps([1, 2, 3]), encoding="utf-8")
+    monkeypatch.setattr(scanner, "_PACK_PATH", str(bad))
+    repo = _skill(tmp_path, "source github.com/live/repo")
+    # Owner is live (200) -> no finding, and crucially: no exception raised.
+    assert scanner.scan_repo(repo) == []


### PR DESCRIPTION
## What

New scanner **`scan_dead_anchors.py`** that detects the **SkillJacking** attack class ([AIR Security research](https://www.air.security/blog-posts/skilljacking)): external anchors a skill references (GitHub owner/repo, prose install-command package names, domains, cloud-hosting subdomains) that are **dead and therefore claimable** by an attacker.

The insight AIR proved and every existing scanner missed: a clean content scan is *point-in-time*. A skill can go hostile with **zero file changes** the moment an attacker re-registers a deleted GitHub username, publishes a phantom package, buys a lapsed domain, or reclaims a dangling `*.vercel.app`. "Victims just need to use it one more time."

## Detections

**P0 (this PR):**
- Repojacking — GitHub user/repo 404 (re-registerable owner)
- Phantom package — npm/PyPI registry 404 (squattable)
- Dead domain — RDAP 404 (registerable)
- Dangling cloud subdomain — DNS NXDOMAIN (+ strict provider fingerprints as corroboration)
- DA-09 free-tier-hosting flag, DA-10 GitHub-owner trust signals

**Deferred to Phase 2:** verdict-decay/time-based recheck, content-drift hashing, reasoning-layer detection (documented in the plan).

## Design guarantees

- **Three-tier verdicts** — only CONFIRMED-CLAIMABLE emits a finding; LIVE-AND-OWNED and COULDNT-CHECK are silent. Biased hard against false CRITICALs.
- **Offline-first** — `--offline` degrades every anchor to silent; zero non-stdlib deps; all network through the hardened `vuln_feed._https_fetch`.
- **Loop-safe / race-safe / lightweight** — single-attempt-no-retry probes, per-host circuit breaker, no-redirect openers (SSRF-safe) + private/link-local/metadata IP backstop, atomic lock-free 24h cache, anchor dedup, hard caps (GH ≤ 20, total ≤ 50), global network deadline, regular-file guard (FIFO-DoS-safe), malformed-rulepack → silent no-op.

## How it was built

Research (AIR + Orca + Mitiga + arXiv/ToxicSkills/SkillSieve) → spec → CE plan → build → **5-agent torture-room gauntlet** → fix → verify.

The gauntlet found and this PR fixes **4 CRITICAL** (redirect-following/SSRF, cloud-subdomain false-CRITICAL, malformed-pack crash, FIFO DoS) + **5 HIGH** (case-normalization, per-probe timeout, RDAP/IPv6 correctness, IP allowlist backstop). Torture report + build decisions in the session artifacts.

## Why it beats the state of the art

AIR's scanner is closed hosted SaaS with no published methodology or dataset. This is **OSS, offline-capable, free**, and wired into the existing 25-scanner correlation engine and signed IOC feed.

## Tests

- Full suite: **1987 passed, 1 skipped** (+20 new regression tests, one per torture finding).
- All 6 spec §10 loop-safety torture cases pass; benign-corpus FP gate stays green; rulepack self-tests pass; all test network monkeypatched (no real HTTP/DNS).
- True-positive paths verified preserved: GitHub-user-404, npm/PyPI-404, RDAP-404, cloud-NXDOMAIN.

## Pre-merge note

Version bump not included in this PR — left as the release step so the version-drift sweep across all version-bearing files happens deliberately, not partially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
