### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #35)

### DIFF
--- a/plugins/repo-forensics/skills/forensify/SKILL.md
+++ b/plugins/repo-forensics/skills/forensify/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   version: 1.0.0
 allowed-tools: Bash Read Glob Grep
 user-invocable: true
-argument-hint: [--target PATH] [--inventory] [--domains NAMES] [--list-runs] [--dry-run] [--format md|json|both] [--include-shadows]
+argument-hint: "[--target PATH] [--inventory] [--domains NAMES] [--list-runs] [--dry-run] [--format md|json|both] [--include-shadows]"
 ---
 
 # Forensify

--- a/skills/forensify/SKILL.md
+++ b/skills/forensify/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   version: 1.0.0
 allowed-tools: Bash Read Glob Grep
 user-invocable: true
-argument-hint: [--target PATH] [--inventory] [--domains NAMES] [--list-runs] [--dry-run] [--format md|json|both] [--include-shadows]
+argument-hint: "[--target PATH] [--inventory] [--domains NAMES] [--list-runs] [--dry-run] [--format md|json|both] [--include-shadows]"
 ---
 
 # Forensify


### PR DESCRIPTION
Closes #35.

## Summary

Purely mechanical single-character transform to 2 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (2)

- `skills/forensify/SKILL.md`
- `plugins/repo-forensics/skills/forensify/SKILL.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
