### PR TITLE
fix: two automatic paths report clean over a scan that found findings

### DIFF
--- a/plugins/repo-forensics/skills/forensify/orchestrator/scanner_driver.py
+++ b/plugins/repo-forensics/skills/forensify/orchestrator/scanner_driver.py
@@ -20,6 +20,15 @@ from typing import Any, Dict, List, Optional
 
 from .contracts import DomainJob
 
+# Exit-code contract of the scanner suite. The codes are defined by
+# aggregate_json.calculate_report_exit_code() —
+#   0  = clean, 1 = HIGH/MEDIUM findings, 2 = CRITICAL findings,
+#   99 = infrastructure error —
+# and run_forensics.sh's final `case` block clamps anything else to 99.
+# 0, 1 and 2 each write a complete aggregate report to stdout and are results;
+# only 99 and anything unforeseen are failures.
+SCANNER_REPORT_EXIT_CODES = (0, 1, 2)
+
 
 def find_scanner_script() -> Optional[str]:
     """Locate run_forensics.sh relative to this file."""
@@ -69,8 +78,7 @@ def run_scanners(
     except OSError as e:
         return {"_error": "subprocess_failed", "detail": str(e)}
 
-    if result.returncode not in (0, 1):
-        # Exit 1 = warnings found (normal). Anything else is unexpected.
+    if result.returncode not in SCANNER_REPORT_EXIT_CODES:
         return {
             "_error": "scanner_exit_%d" % result.returncode,
             "stderr": result.stderr[:500] if result.stderr else "",

--- a/plugins/repo-forensics/skills/repo-forensics/checksums.json
+++ b/plugins/repo-forensics/skills/repo-forensics/checksums.json
@@ -79,7 +79,7 @@
     "scripts/scan_skill_threats.py": "05452f244b1c0f5259d2f45a41593c1a1b82d7caad39f6b1efb0b87f02c09729",
     "scripts/scan_splitstream.py": "4fd98a612442a8c241e8796f984e6ecce3e43be7334355bf84f2ad408f556319",
     "scripts/scan_yara.py": "0272b4de75c8af5c461bfda86287254f1be9dfd31cfa20e2ebe91a55a8a35256",
-    "scripts/session_scan.py": "bae31804288971171aadabee9924d0bd43931df400f22041b289eee0e3dfd1e3",
+    "scripts/session_scan.py": "88159342f34a18d5ff066060b6aa7750d406df64d94475cf3df06e9032c4a33a",
     "scripts/validate_manifests.py": "a0926bc0a0b86ca59a2d66036a8bce403d4d4a0793bf799af8554e3c36ef43c9",
     "scripts/verify_install.py": "b98802487a4483f53553ef106ad82692ea92ad2b94972f73684e52d29c468034",
     "scripts/vuln_feed.py": "0b56e20969beb8fbc59650114a34ac8743d1a0862ff3ae56b07e92d2e368a141"

--- a/plugins/repo-forensics/skills/repo-forensics/checksums.json
+++ b/plugins/repo-forensics/skills/repo-forensics/checksums.json
@@ -79,7 +79,7 @@
     "scripts/scan_skill_threats.py": "05452f244b1c0f5259d2f45a41593c1a1b82d7caad39f6b1efb0b87f02c09729",
     "scripts/scan_splitstream.py": "4fd98a612442a8c241e8796f984e6ecce3e43be7334355bf84f2ad408f556319",
     "scripts/scan_yara.py": "0272b4de75c8af5c461bfda86287254f1be9dfd31cfa20e2ebe91a55a8a35256",
-    "scripts/session_scan.py": "aa8040754b471737f2611293f0356e04955e9e66c7f9fca44d688b0d2860cc08",
+    "scripts/session_scan.py": "ee57ced0de7681163b76b0507bad2dc79d457eb7562a3fc2de9cca469c1c1c26",
     "scripts/validate_manifests.py": "a0926bc0a0b86ca59a2d66036a8bce403d4d4a0793bf799af8554e3c36ef43c9",
     "scripts/verify_install.py": "b98802487a4483f53553ef106ad82692ea92ad2b94972f73684e52d29c468034",
     "scripts/vuln_feed.py": "0b56e20969beb8fbc59650114a34ac8743d1a0862ff3ae56b07e92d2e368a141"

--- a/plugins/repo-forensics/skills/repo-forensics/checksums.json
+++ b/plugins/repo-forensics/skills/repo-forensics/checksums.json
@@ -79,7 +79,7 @@
     "scripts/scan_skill_threats.py": "05452f244b1c0f5259d2f45a41593c1a1b82d7caad39f6b1efb0b87f02c09729",
     "scripts/scan_splitstream.py": "4fd98a612442a8c241e8796f984e6ecce3e43be7334355bf84f2ad408f556319",
     "scripts/scan_yara.py": "0272b4de75c8af5c461bfda86287254f1be9dfd31cfa20e2ebe91a55a8a35256",
-    "scripts/session_scan.py": "ee57ced0de7681163b76b0507bad2dc79d457eb7562a3fc2de9cca469c1c1c26",
+    "scripts/session_scan.py": "bae31804288971171aadabee9924d0bd43931df400f22041b289eee0e3dfd1e3",
     "scripts/validate_manifests.py": "a0926bc0a0b86ca59a2d66036a8bce403d4d4a0793bf799af8554e3c36ef43c9",
     "scripts/verify_install.py": "b98802487a4483f53553ef106ad82692ea92ad2b94972f73684e52d29c468034",
     "scripts/vuln_feed.py": "0b56e20969beb8fbc59650114a34ac8743d1a0862ff3ae56b07e92d2e368a141"

--- a/plugins/repo-forensics/skills/repo-forensics/checksums.json
+++ b/plugins/repo-forensics/skills/repo-forensics/checksums.json
@@ -79,7 +79,7 @@
     "scripts/scan_skill_threats.py": "05452f244b1c0f5259d2f45a41593c1a1b82d7caad39f6b1efb0b87f02c09729",
     "scripts/scan_splitstream.py": "4fd98a612442a8c241e8796f984e6ecce3e43be7334355bf84f2ad408f556319",
     "scripts/scan_yara.py": "0272b4de75c8af5c461bfda86287254f1be9dfd31cfa20e2ebe91a55a8a35256",
-    "scripts/session_scan.py": "e0c4c5326059733126fa3bbb00ead2adc2f0df5f43e81958f015d24918ddefe7",
+    "scripts/session_scan.py": "aa8040754b471737f2611293f0356e04955e9e66c7f9fca44d688b0d2860cc08",
     "scripts/validate_manifests.py": "a0926bc0a0b86ca59a2d66036a8bce403d4d4a0793bf799af8554e3c36ef43c9",
     "scripts/verify_install.py": "b98802487a4483f53553ef106ad82692ea92ad2b94972f73684e52d29c468034",
     "scripts/vuln_feed.py": "0b56e20969beb8fbc59650114a34ac8743d1a0862ff3ae56b07e92d2e368a141"

--- a/plugins/repo-forensics/skills/repo-forensics/scripts/session_scan.py
+++ b/plugins/repo-forensics/skills/repo-forensics/scripts/session_scan.py
@@ -597,7 +597,7 @@ def _is_above_report_floor(item):
     deliberate: this field is attacker-controlled -- load_scanner_results()
     copies each scanner's JSON through verbatim -- so a floor that swallowed
     off-vocabulary severities would hand a scanned repository a one-word way
-    to suppress its own worst finding, trading the false clean this reader
+    to suppress its own worst finding, trading the false-clean this reader
     exists to remove for a narrower one. It renders `UNKNOWN` and sorts below
     every ranked finding, so it can neither hide nor crowd one out.
     """
@@ -624,7 +624,7 @@ def _format_overflow_line(hidden):
     """The one line a capped report owes the reader.
 
     Truncation is silent unless it says so, and a silent truncation is the
-    same defect class as the false clean above it: a report that showed five
+    same defect class as the false-clean above it: a report that showed five
     of nine findings and looked exactly like a report that found five. The
     count and the per-severity breakdown are what make the difference visible
     without adding another line per hidden finding.
@@ -699,7 +699,7 @@ def summarize_deep_findings(report):
     it arrived: free text is sanitized, and the severity -- which is not free
     text but a four-word vocabulary -- is checked against it. That is a
     condition of the repair, not a refinement of it: reporting the findings
-    without neutralizing them would trade a false clean for an injection path
+    without neutralizing them would trade a false-clean for an injection path
     into SessionStart.
 
     What reaches the reader is then bounded twice: DEEP_FINDING_REPORT_FLOOR
@@ -806,7 +806,7 @@ def deep_scan_item(dirpath, label, item_type, timeout=None, adjudication_sink=No
     if not findings:
         # Silence is not an available answer past this point -- see
         # _format_uncleared_scan_line(). The item is reported uncleared as
-        # well as spoken about, because a false clean that gets baselined is
+        # well as spoken about, because a false-clean that gets baselined is
         # not one missed report, it is every future one.
         if uncleared_sink is not None:
             uncleared_sink.append(f"{item_type}:{dirpath}")

--- a/plugins/repo-forensics/skills/repo-forensics/scripts/session_scan.py
+++ b/plugins/repo-forensics/skills/repo-forensics/scripts/session_scan.py
@@ -702,14 +702,14 @@ def summarize_deep_findings(report):
     without neutralizing them would trade a false clean for an injection path
     into SessionStart.
 
-    What reaches the reader is then bounded twice, because the report competes
-    with the session for the same context window. DEEP_FINDING_REPORT_FLOOR
-    drops the notes; DEEP_FINDING_MAX_LINES bounds how many lines one item can
-    occupy. Sorting happens here rather than being taken from the report: the
-    aggregator does sort worst-first, but the report is a scanner's stdout and
-    this is the last thing between it and the user, so truncating on a trusted
-    order would let a producer decide which finding the owner never sees. The
-    sort is stable, so findings of one severity keep the order they arrived in.
+    What reaches the reader is then bounded twice: DEEP_FINDING_REPORT_FLOOR
+    drops the notes, and DEEP_FINDING_MAX_LINES bounds how many lines one item
+    can occupy -- see each constant, which explains why it is there. Sorting
+    happens here rather than being taken from the report: the aggregator does
+    sort worst-first, but the report is a scanner's stdout and this is the last
+    thing between it and the user, so truncating on a trusted order would let a
+    producer decide which finding the owner never sees. The sort is stable, so
+    findings of one severity keep the order they arrived in.
 
     Nothing here spawns a subprocess or reads the scanned tree, so the
     rendering can be exercised without one; deep_scan_item() owns the

--- a/plugins/repo-forensics/skills/repo-forensics/scripts/session_scan.py
+++ b/plugins/repo-forensics/skills/repo-forensics/scripts/session_scan.py
@@ -481,7 +481,251 @@ def scan_item(dirpath, label, item_type, checksums):
     return findings
 
 
-def deep_scan_item(dirpath, label, item_type, timeout=None, adjudication_sink=None):
+# Per-field caps for a rendered finding line. The session report is echoed
+# into the agent's context, so length is bounded per field as well as per
+# line. All three are the caps this codebase already applies to the same
+# fields: title and description in aggregate_json.format_report_as_text() and
+# adjudication.build_adjudication_block(), the path in the latter -- the text
+# formatter is the odd one out and does not sanitize its path at all.
+DEEP_FINDING_TITLE_MAX = 160
+DEEP_FINDING_DESC_MAX = 300
+DEEP_FINDING_PATH_MAX = 160
+
+# The aggregator's severity vocabulary, mirrored rather than imported:
+# session_scan is a SessionStart hook on a 15s budget and deliberately imports
+# no heavy scanner module. TestDeepScanFindingsReachTheSession pins this tuple
+# against aggregate_json.SEVERITY_ORDER so the mirror cannot drift -- its
+# members and, since the reader sorts by position in it, its order.
+DEEP_FINDING_SEVERITIES = ("critical", "high", "medium", "low")
+
+# Severities worth a line at session start. `low` is deliberately excluded: it
+# is an informational note, and a note that turns every plugin update into a
+# warning line spends the report's credibility on nothing. A report nobody
+# reads is not a control, it is an alibi.
+#
+# A severity the vocabulary does not contain is NOT below this floor -- see
+# _is_above_report_floor(), which explains why.
+DEEP_FINDING_REPORT_FLOOR = ("critical", "high", "medium")
+
+# Finding lines one changed item may spend, before the overflow line. This
+# return value is echoed into the agent's session context, so an uncapped
+# report from one noisy target pushes the rest of the session out of the
+# window. The cap is lossy by construction, which is why _format_overflow_line()
+# exists: a capped report that did not say so would read as a complete one.
+DEEP_FINDING_MAX_LINES = 5
+
+
+def _snippet_sanitizer():
+    """Return the sanitizer used for finding-derived text.
+
+    Same lazy import and same stdlib fallback aggregate_json.format_report_as_text()
+    uses for the same fields, so there is one neutralization behaviour in this
+    codebase rather than two that can drift. The fallback's character ranges are
+    that formatter's, written as escapes: C0/C1 controls plus the BIDI
+    overrides (U+202A-U+202E) and isolates (U+2066-U+2069).
+    """
+    try:
+        import adjudication as _adj
+        return _adj.sanitize_snippet
+    except ImportError:
+        import re as _re
+
+        def _sanitize(text, max_len=300):
+            if not isinstance(text, str):
+                return ""
+            cleaned = _re.sub(
+                "[\x00-\x1f\x7f\x80-\x9f\u202a-\u202e\u2066-\u2069]", "", text
+            )
+            cleaned = _re.sub(r"\s+", " ", cleaned).strip()
+            return cleaned[:max_len]
+
+        return _sanitize
+
+
+def _format_finding_location(item, sanitize):
+    """`file:line` for a finding, or `file` when the scanner gave no line."""
+    path = sanitize(item.get("file") or "", max_len=DEEP_FINDING_PATH_MAX)
+    if not path:
+        return "location unknown"
+    try:
+        line_no = int(item.get("line") or 0)
+    except (TypeError, ValueError):
+        line_no = 0
+    return f"{path}:{line_no}" if line_no > 0 else path
+
+
+def _format_finding_severity(item):
+    """The finding's severity tag, or `UNKNOWN` for anything off-vocabulary.
+
+    Checked against the vocabulary rather than sanitized. Nothing downstream
+    validates this field -- load_scanner_results() copies each scanner's JSON
+    through verbatim -- so a scanned repository controls it exactly as it
+    controls the title, and a severity of "high\n[CRITICAL] ..." would forge a
+    top-level line. Sanitizing would neutralize that; refusing the value
+    outright also refuses to show the reader a severity the aggregator cannot
+    rank, which is the more honest failure.
+    """
+    severity = item.get("severity")
+    if isinstance(severity, str) and severity.lower() in DEEP_FINDING_SEVERITIES:
+        return severity.upper()
+    return "UNKNOWN"
+
+
+def _severity_rank(item):
+    """Sort key for a finding: 0 is worst.
+
+    Position in DEEP_FINDING_SEVERITIES, which is the aggregator's ranking
+    mirrored worst-first. Anything off the vocabulary ranks after every known
+    severity, so an unrankable value cannot be used to claim the top of a
+    capped report.
+    """
+    severity = item.get("severity")
+    if isinstance(severity, str):
+        try:
+            return DEEP_FINDING_SEVERITIES.index(severity.lower())
+        except ValueError:
+            pass
+    return len(DEEP_FINDING_SEVERITIES)
+
+
+def _is_above_report_floor(item):
+    """Is this finding worth one of the session report's lines?
+
+    A recognized severity is tested against DEEP_FINDING_REPORT_FLOOR. An
+    unrecognized one is reported instead of dropped, and that asymmetry is
+    deliberate: this field is attacker-controlled -- load_scanner_results()
+    copies each scanner's JSON through verbatim -- so a floor that swallowed
+    off-vocabulary severities would hand a scanned repository a one-word way
+    to suppress its own worst finding, trading the false clean this reader
+    exists to remove for a narrower one. It renders `UNKNOWN` and sorts below
+    every ranked finding, so it can neither hide nor crowd one out.
+    """
+    severity = item.get("severity")
+    if isinstance(severity, str) and severity.lower() in DEEP_FINDING_SEVERITIES:
+        return severity.lower() in DEEP_FINDING_REPORT_FLOOR
+    return True
+
+
+def _format_finding_line(item, sanitize):
+    """One display line: severity, what was found, where, and why it matters."""
+    title = sanitize(item.get("title") or "", max_len=DEEP_FINDING_TITLE_MAX)
+    description = sanitize(item.get("description") or "", max_len=DEEP_FINDING_DESC_MAX)
+    line = (
+        f"[{_format_finding_severity(item)}] {title or 'untitled finding'} "
+        f"({_format_finding_location(item, sanitize)})"
+    )
+    if description:
+        line += f" - {description}"
+    return line
+
+
+def _format_overflow_line(hidden):
+    """The one line a capped report owes the reader.
+
+    Truncation is silent unless it says so, and a silent truncation is the
+    same defect class as the false clean above it: a report that showed five
+    of nine findings and looked exactly like a report that found five. The
+    count and the per-severity breakdown are what make the difference visible
+    without spending another line per hidden finding.
+
+    Carries no attacker-controlled text -- only integers and severity tags
+    already checked against the vocabulary -- and deliberately does not start
+    with `[`, so it cannot be mistaken for one more finding line.
+    """
+    counts = {}
+    for item in sorted(hidden, key=_severity_rank):
+        tag = _format_finding_severity(item)
+        counts[tag] = counts.get(tag, 0) + 1
+    breakdown = ", ".join(f"{count} {tag}" for tag, count in counts.items())
+    noun = "finding" if len(hidden) == 1 else "findings"
+    return f"... and {len(hidden)} more {noun} not shown ({breakdown})"
+
+
+def _format_uncleared_scan_line(returncode):
+    """The one line a scan owes the reader when it rendered nothing.
+
+    Reached only past the early returns for exit 0 and for a signal death, so
+    the scan ended nonzero and the reader still produced nothing: the report
+    was unparseable at a code deep_scan_item()'s own fallbacks do not cover,
+    or every finding in it sat below DEEP_FINDING_REPORT_FLOOR, or its shape
+    was not one this reader knows. All three are problems inside the tool,
+    and the owner cannot tell them apart from here -- but reporting the item
+    `clean` would tell them the one thing that is certainly false.
+
+    The exit code is in the line because it is the only handle the owner has
+    on which of those happened: 99 is an infrastructure failure, 1 and 2 are
+    findings the reader could not render. Carries no attacker-controlled text
+    -- an integer from waitpid and nothing else -- and deliberately does not
+    start with `[`, so it cannot be mistaken for a finding line.
+    """
+    return (
+        f"deep scan exited {returncode} with no reportable finding "
+        f"(not cleared; will be re-reported next session)"
+    )
+
+
+def report_findings(report):
+    """The report's finding list, or empty for anything that is not one.
+
+    Both readers of `report["findings"]` go through here, and the type checks
+    are load-bearing rather than defensive habit: the report is parsed from a
+    scanner's stdout, so any field can be any JSON type, and `for item in 5`
+    raises a TypeError that deep_scan_item()'s
+    `except (json.JSONDecodeError, ValueError)` does not catch -- breaking its
+    documented promise never to raise, and taking the SessionStart hook with
+    it.
+    """
+    if not isinstance(report, dict):
+        return []
+    items = report.get("findings")
+    if not isinstance(items, (list, tuple)):
+        return []
+    return [item for item in items if isinstance(item, dict)]
+
+
+def summarize_deep_findings(report):
+    """Render a parsed aggregate report's findings as session display lines.
+
+    Severity is read from each finding, because that is the only place the
+    aggregator puts one. An entry of `report["scanners"]` carries exactly
+    `name`, `exit_code`, `parse_error`, `finding_count`, `findings`, plus
+    `stderr` when present -- never a severity. A reader that looked for one
+    there collected nothing and printed `clean` over a scan that exited 2 on a
+    CRITICAL finding, which is the defect this function exists to fix.
+
+    Every rendered field originates in the scanned tree and this return value
+    is echoed into the agent's session context, so none of it is rendered as
+    it arrived: free text is sanitized, and the severity -- which is not free
+    text but a four-word vocabulary -- is checked against it. That is a
+    condition of the repair, not a refinement of it: reporting the findings
+    without neutralizing them would trade a false clean for an injection path
+    into SessionStart.
+
+    What reaches the reader is then bounded twice, because the report competes
+    with the session for the same context window. DEEP_FINDING_REPORT_FLOOR
+    drops the notes; DEEP_FINDING_MAX_LINES bounds what one noisy target can
+    spend. Sorting happens here rather than being taken from the report: the
+    aggregator does sort worst-first, but the report is a scanner's stdout and
+    this is the last thing between it and the user, so truncating on a trusted
+    order would let a producer decide which finding the owner never sees. The
+    sort is stable, so findings of one severity keep the order they arrived in.
+
+    Nothing here spawns a subprocess or reads the scanned tree, so the
+    rendering can be exercised without one; deep_scan_item() owns the
+    subprocess and hands the parsed report in.
+    """
+    sanitize = _snippet_sanitizer()
+    items = [item for item in report_findings(report) if _is_above_report_floor(item)]
+    items.sort(key=_severity_rank)
+    shown, hidden = items[:DEEP_FINDING_MAX_LINES], items[DEEP_FINDING_MAX_LINES:]
+    lines = [_format_finding_line(item, sanitize) for item in shown]
+    if hidden:
+        lines.append(_format_overflow_line(hidden))
+    return lines
+
+
+def deep_scan_item(dirpath, label, item_type, timeout=None, adjudication_sink=None,
+                   uncleared_sink=None):
     """Run the full run_forensics.sh scanner suite on a changed item.
 
     On POSIX, uses start_new_session=True so the entire process tree
@@ -490,7 +734,13 @@ def deep_scan_item(dirpath, label, item_type, timeout=None, adjudication_sink=No
     scanner zombies. Windows lacks os.getpgid/os.killpg, so it falls
     back to killing the direct subprocess.
 
-    Returns list of finding strings (empty = clean). Never raises.
+    Returns list of finding strings. Never raises. A scan that actually ran
+    and ended nonzero never returns an empty list: if it renders no finding it
+    returns one line naming its exit code rather than going quiet, and appends
+    the item's baseline key to *uncleared_sink* so main() can keep it out of
+    the baseline. The early returns above -- no scanner script, no such
+    directory, no time budget left, an OSError launching it -- still return []
+    and leave the sink untouched.
     """
     if not os.path.isfile(RUN_FORENSICS_SCRIPT):
         return []
@@ -538,27 +788,28 @@ def deep_scan_item(dirpath, label, item_type, timeout=None, adjudication_sink=No
     try:
         data = json.loads(stdout)
         if isinstance(data, dict):
-            for scanner in data.get('scanners', []):
-                if not isinstance(scanner, dict):
-                    continue
-                sev = scanner.get('severity', '')
-                if sev in ('critical', 'high', 'warning'):
-                    scanner_name = scanner.get('name', 'unknown')
-                    detail = scanner.get('detail', scanner.get('message', ''))
-                    if detail:
-                        findings.append(f"[{sev.upper()}] {scanner_name}: {detail}")
+            findings.extend(summarize_deep_findings(data))
             # Collect WARN-tier findings flagged for adjudication (U8). These
             # carry needs_adjudication=true from aggregate_json; they feed the
             # injection-safe adjudication block built once in main().
             if adjudication_sink is not None:
-                for finding in data.get('findings', []):
-                    if isinstance(finding, dict) and finding.get('needs_adjudication') is True:
+                for finding in report_findings(data):
+                    if finding.get('needs_adjudication') is True:
                         adjudication_sink.append(finding)
     except (json.JSONDecodeError, ValueError):
         if proc.returncode == 2:
             findings.append("deep scan found CRITICAL issues (parse failed, check manually)")
         elif proc.returncode == 1:
             findings.append("deep scan found warnings (parse failed, check manually)")
+
+    if not findings:
+        # Silence is not an available answer past this point -- see
+        # _format_uncleared_scan_line(). The item is reported uncleared as
+        # well as spoken about, because a false clean that gets baselined is
+        # not one missed report, it is every future one.
+        if uncleared_sink is not None:
+            uncleared_sink.append(f"{item_type}:{dirpath}")
+        findings.append(_format_uncleared_scan_line(proc.returncode))
 
     return findings
 
@@ -809,6 +1060,7 @@ def main(argv=None):
     # Only runs when items actually changed (rare). Skipped on first run
     # (too many items) and when run_forensics.sh is missing.
     adjudication_findings = []
+    uncleared_items = []
     if scan_items and not is_first_run and os.path.isfile(RUN_FORENSICS_SCRIPT):
         deep_start = time.monotonic()
         for dirpath, label, itype, checksums in scan_items:
@@ -821,7 +1073,8 @@ def main(argv=None):
                 break
             deep_findings = deep_scan_item(dirpath, label, itype, timeout=min(
                 DEEP_SCAN_TIMEOUT_PER_ITEM, remaining
-            ), adjudication_sink=adjudication_findings)
+            ), adjudication_sink=adjudication_findings,
+                uncleared_sink=uncleared_items)
             scan_results.setdefault(f"{itype}:{dirpath}", []).extend(deep_findings)
 
     # Format output
@@ -847,6 +1100,16 @@ def main(argv=None):
     # detect_changes already produced fresh entries for every item; reuse them
     # directly instead of re-walking the tree. Avoids ~150-300ms of redundant
     # stat syscalls on warm sessions.
+    #
+    # An item whose deep scan ended nonzero and rendered nothing was never
+    # cleared, so it is dropped from the snapshot rather than written into it.
+    # Baselining it would silence the same result at every future session
+    # start -- detect_changes() reports only items whose hashes moved -- which
+    # turns one failure the owner could act on into a permanent one they never
+    # see again. Dropping the key costs that item its incremental-hash cache
+    # on the next run and nothing else.
+    for item_key in uncleared_items:
+        all_entries.pop(item_key, None)
     save_baseline(all_entries)
 
     output_session_context(lines, adapter=adapter)

--- a/plugins/repo-forensics/skills/repo-forensics/scripts/session_scan.py
+++ b/plugins/repo-forensics/skills/repo-forensics/scripts/session_scan.py
@@ -500,16 +500,17 @@ DEEP_FINDING_SEVERITIES = ("critical", "high", "medium", "low")
 
 # Severities worth a line at session start. `low` is deliberately excluded: it
 # is an informational note, and a note that turns every plugin update into a
-# warning line spends the report's credibility on nothing. A report nobody
-# reads is not a control, it is an alibi.
+# warning line trains the reader to skip the report. A skipped report is not
+# read as "nothing was said" but as "nothing was found" -- the same false-clean
+# a nonzero scan reporting nothing would be.
 #
 # A severity the vocabulary does not contain is NOT below this floor -- see
 # _is_above_report_floor(), which explains why.
 DEEP_FINDING_REPORT_FLOOR = ("critical", "high", "medium")
 
-# Finding lines one changed item may spend, before the overflow line. This
+# Finding lines one changed item may occupy, before the overflow line. This
 # return value is echoed into the agent's session context, so an uncapped
-# report from one noisy target pushes the rest of the session out of the
+# report from one finding-heavy item pushes the rest of the session out of the
 # window. The cap is lossy by construction, which is why _format_overflow_line()
 # exists: a capped report that did not say so would read as a complete one.
 DEEP_FINDING_MAX_LINES = 5
@@ -626,7 +627,7 @@ def _format_overflow_line(hidden):
     same defect class as the false clean above it: a report that showed five
     of nine findings and looked exactly like a report that found five. The
     count and the per-severity breakdown are what make the difference visible
-    without spending another line per hidden finding.
+    without adding another line per hidden finding.
 
     Carries no attacker-controlled text -- only integers and severity tags
     already checked against the vocabulary -- and deliberately does not start
@@ -703,8 +704,8 @@ def summarize_deep_findings(report):
 
     What reaches the reader is then bounded twice, because the report competes
     with the session for the same context window. DEEP_FINDING_REPORT_FLOOR
-    drops the notes; DEEP_FINDING_MAX_LINES bounds what one noisy target can
-    spend. Sorting happens here rather than being taken from the report: the
+    drops the notes; DEEP_FINDING_MAX_LINES bounds how many lines one item can
+    occupy. Sorting happens here rather than being taken from the report: the
     aggregator does sort worst-first, but the report is a scanner's stdout and
     this is the last thing between it and the user, so truncating on a trusted
     order would let a producer decide which finding the owner never sees. The

--- a/skills/forensify/orchestrator/scanner_driver.py
+++ b/skills/forensify/orchestrator/scanner_driver.py
@@ -20,6 +20,15 @@ from typing import Any, Dict, List, Optional
 
 from .contracts import DomainJob
 
+# Exit-code contract of the scanner suite. The codes are defined by
+# aggregate_json.calculate_report_exit_code() —
+#   0  = clean, 1 = HIGH/MEDIUM findings, 2 = CRITICAL findings,
+#   99 = infrastructure error —
+# and run_forensics.sh's final `case` block clamps anything else to 99.
+# 0, 1 and 2 each write a complete aggregate report to stdout and are results;
+# only 99 and anything unforeseen are failures.
+SCANNER_REPORT_EXIT_CODES = (0, 1, 2)
+
 
 def find_scanner_script() -> Optional[str]:
     """Locate run_forensics.sh relative to this file."""
@@ -69,8 +78,7 @@ def run_scanners(
     except OSError as e:
         return {"_error": "subprocess_failed", "detail": str(e)}
 
-    if result.returncode not in (0, 1):
-        # Exit 1 = warnings found (normal). Anything else is unexpected.
+    if result.returncode not in SCANNER_REPORT_EXIT_CODES:
         return {
             "_error": "scanner_exit_%d" % result.returncode,
             "stderr": result.stderr[:500] if result.stderr else "",

--- a/skills/forensify/tests/test_scanner_driver.py
+++ b/skills/forensify/tests/test_scanner_driver.py
@@ -1,0 +1,163 @@
+"""
+Exit-code contract of scanner_driver.run_scanners().
+
+run_forensics.sh ends in `case "$_rc" in 0|1|2) exit "$_rc" ;; *) exit 99 ;; esac`:
+exit 0, 1 and 2 each write a complete aggregate report to stdout and are
+results; 99 is an infrastructure failure. The driver must keep the report for
+every result code and return an error only for 99 and the unforeseen, so
+"the scanner broke" and "the scanner found nothing" stay distinguishable.
+
+The subprocess is faked with a stub script — the pattern TestDeepScanItem
+established in skills/repo-forensics/tests/test_session_scan.py — so these
+tests pin the driver's exit-code contract, not the scanners.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ORCH_DIR = Path(__file__).resolve().parent.parent / "orchestrator"
+sys.path.insert(0, str(ORCH_DIR.parent))
+
+from orchestrator import scanner_driver  # noqa: E402
+
+_POSIX_ONLY = pytest.mark.skipif(
+    os.name == "nt", reason="POSIX shell/process behavior not available on Windows"
+)
+
+
+def aggregate_payload(severities=()):
+    """A minimal aggregate report carrying one finding per requested severity.
+
+    The driver treats stdout as opaque JSON, so the contract assertion is
+    equality: whatever the scan wrote is what the caller receives.
+    """
+    return {
+        "findings": [
+            {
+                "finding_id": "f-%s-%d" % (sev, i),
+                "severity": sev,
+                "title": "finding %s" % sev,
+                "file": "payload/%d.py" % i,
+            }
+            for i, sev in enumerate(severities)
+        ],
+        "scanners": [],
+    }
+
+
+def stub_scanner(tmp_path, monkeypatch, payload, exit_code):
+    """Fake run_forensics.sh: print a chosen payload, exit with a chosen code."""
+    script = tmp_path / "fake_run_forensics.sh"
+    body = payload if isinstance(payload, str) else json.dumps(payload)
+    script.write_text("#!/bin/bash\ncat <<'PAYLOAD'\n%s\nPAYLOAD\nexit %d\n" % (body, exit_code))
+    script.chmod(0o755)
+    monkeypatch.setattr(scanner_driver, "find_scanner_script", lambda: str(script))
+
+
+@pytest.fixture
+def target_dir(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir()
+    return str(target)
+
+
+@_POSIX_ONLY
+class TestRunScannersKeepsTheReport:
+    def test_critical_findings_return_the_report_not_an_error(
+        self, tmp_path, monkeypatch, target_dir
+    ):
+        """The defect, stated as a test: exit 2 used to discard the report on stdout."""
+        payload = aggregate_payload(["critical"])
+        stub_scanner(tmp_path, monkeypatch, payload, 2)
+
+        result = scanner_driver.run_scanners(target_dir)
+
+        assert "_error" not in result
+        assert result == payload
+        assert result["findings"][0]["severity"] == "critical"
+
+    @pytest.mark.parametrize(
+        "exit_code,severities",
+        [(0, []), (1, ["high", "medium"]), (2, ["critical"])],
+        ids=["clean", "high-medium", "critical"],
+    )
+    def test_each_report_exit_code_returns_the_complete_report(
+        self, tmp_path, monkeypatch, target_dir, exit_code, severities
+    ):
+        payload = aggregate_payload(severities)
+        stub_scanner(tmp_path, monkeypatch, payload, exit_code)
+
+        result = scanner_driver.run_scanners(target_dir)
+
+        assert result == payload
+
+
+@_POSIX_ONLY
+class TestRunScannersKeepsFailuresAsErrors:
+    def test_infrastructure_failure_stays_an_error(self, tmp_path, monkeypatch, target_dir):
+        """Exit 99 must not become a report: "the scanner broke" and "the scanner
+        found nothing" stay distinguishable."""
+        stub_scanner(tmp_path, monkeypatch, aggregate_payload(), 99)
+
+        result = scanner_driver.run_scanners(target_dir)
+
+        assert result["_error"] == "scanner_exit_99"
+
+    @pytest.mark.parametrize("exit_code", [3, 124, 127])
+    def test_an_unforeseen_exit_code_is_an_error(
+        self, tmp_path, monkeypatch, target_dir, exit_code
+    ):
+        stub_scanner(tmp_path, monkeypatch, aggregate_payload(), exit_code)
+
+        result = scanner_driver.run_scanners(target_dir)
+
+        assert result["_error"] == "scanner_exit_%d" % exit_code
+
+    def test_unparseable_stdout_at_a_report_exit_code_is_an_error(
+        self, tmp_path, monkeypatch, target_dir
+    ):
+        stub_scanner(tmp_path, monkeypatch, "NOT JSON", 0)
+
+        result = scanner_driver.run_scanners(target_dir)
+
+        assert result["_error"] == "invalid_json"
+
+    def test_timeout_is_an_error(self, tmp_path, monkeypatch, target_dir):
+        # The stub closes its streams first so the pipe reaches EOF and the
+        # orphaned sleep cannot hold subprocess.run past its kill.
+        script = tmp_path / "slow_run_forensics.sh"
+        script.write_text("#!/bin/bash\nexec 1>&- 2>&-\nsleep 60\n")
+        script.chmod(0o755)
+        monkeypatch.setattr(scanner_driver, "find_scanner_script", lambda: str(script))
+
+        result = scanner_driver.run_scanners(target_dir, timeout=1)
+
+        assert result["_error"] == "scanner_timeout"
+
+
+class TestRunScannersWithoutASubprocess:
+    def test_missing_script_is_an_error(self, monkeypatch, target_dir):
+        monkeypatch.setattr(scanner_driver, "find_scanner_script", lambda: None)
+
+        result = scanner_driver.run_scanners(target_dir)
+
+        assert result["_error"] == "run_forensics.sh not found"
+
+    def test_non_directory_target_is_an_error(self, tmp_path, monkeypatch):
+        stub_scanner(tmp_path, monkeypatch, aggregate_payload(), 0)
+        target = tmp_path / "a_file.txt"
+        target.write_text("not a directory")
+
+        result = scanner_driver.run_scanners(str(target))
+
+        assert result["_error"] == "target_not_a_directory"
+
+    def test_the_contract_is_a_named_constant(self):
+        """One named place carries the contract; callers must not re-derive it
+        from run_forensics.sh."""
+        assert scanner_driver.SCANNER_REPORT_EXIT_CODES == (0, 1, 2)

--- a/skills/repo-forensics/checksums.json
+++ b/skills/repo-forensics/checksums.json
@@ -79,7 +79,7 @@
     "scripts/scan_skill_threats.py": "05452f244b1c0f5259d2f45a41593c1a1b82d7caad39f6b1efb0b87f02c09729",
     "scripts/scan_splitstream.py": "4fd98a612442a8c241e8796f984e6ecce3e43be7334355bf84f2ad408f556319",
     "scripts/scan_yara.py": "0272b4de75c8af5c461bfda86287254f1be9dfd31cfa20e2ebe91a55a8a35256",
-    "scripts/session_scan.py": "bae31804288971171aadabee9924d0bd43931df400f22041b289eee0e3dfd1e3",
+    "scripts/session_scan.py": "88159342f34a18d5ff066060b6aa7750d406df64d94475cf3df06e9032c4a33a",
     "scripts/validate_manifests.py": "a0926bc0a0b86ca59a2d66036a8bce403d4d4a0793bf799af8554e3c36ef43c9",
     "scripts/verify_install.py": "b98802487a4483f53553ef106ad82692ea92ad2b94972f73684e52d29c468034",
     "scripts/vuln_feed.py": "0b56e20969beb8fbc59650114a34ac8743d1a0862ff3ae56b07e92d2e368a141"

--- a/skills/repo-forensics/checksums.json
+++ b/skills/repo-forensics/checksums.json
@@ -79,7 +79,7 @@
     "scripts/scan_skill_threats.py": "05452f244b1c0f5259d2f45a41593c1a1b82d7caad39f6b1efb0b87f02c09729",
     "scripts/scan_splitstream.py": "4fd98a612442a8c241e8796f984e6ecce3e43be7334355bf84f2ad408f556319",
     "scripts/scan_yara.py": "0272b4de75c8af5c461bfda86287254f1be9dfd31cfa20e2ebe91a55a8a35256",
-    "scripts/session_scan.py": "aa8040754b471737f2611293f0356e04955e9e66c7f9fca44d688b0d2860cc08",
+    "scripts/session_scan.py": "ee57ced0de7681163b76b0507bad2dc79d457eb7562a3fc2de9cca469c1c1c26",
     "scripts/validate_manifests.py": "a0926bc0a0b86ca59a2d66036a8bce403d4d4a0793bf799af8554e3c36ef43c9",
     "scripts/verify_install.py": "b98802487a4483f53553ef106ad82692ea92ad2b94972f73684e52d29c468034",
     "scripts/vuln_feed.py": "0b56e20969beb8fbc59650114a34ac8743d1a0862ff3ae56b07e92d2e368a141"

--- a/skills/repo-forensics/checksums.json
+++ b/skills/repo-forensics/checksums.json
@@ -79,7 +79,7 @@
     "scripts/scan_skill_threats.py": "05452f244b1c0f5259d2f45a41593c1a1b82d7caad39f6b1efb0b87f02c09729",
     "scripts/scan_splitstream.py": "4fd98a612442a8c241e8796f984e6ecce3e43be7334355bf84f2ad408f556319",
     "scripts/scan_yara.py": "0272b4de75c8af5c461bfda86287254f1be9dfd31cfa20e2ebe91a55a8a35256",
-    "scripts/session_scan.py": "ee57ced0de7681163b76b0507bad2dc79d457eb7562a3fc2de9cca469c1c1c26",
+    "scripts/session_scan.py": "bae31804288971171aadabee9924d0bd43931df400f22041b289eee0e3dfd1e3",
     "scripts/validate_manifests.py": "a0926bc0a0b86ca59a2d66036a8bce403d4d4a0793bf799af8554e3c36ef43c9",
     "scripts/verify_install.py": "b98802487a4483f53553ef106ad82692ea92ad2b94972f73684e52d29c468034",
     "scripts/vuln_feed.py": "0b56e20969beb8fbc59650114a34ac8743d1a0862ff3ae56b07e92d2e368a141"

--- a/skills/repo-forensics/checksums.json
+++ b/skills/repo-forensics/checksums.json
@@ -79,7 +79,7 @@
     "scripts/scan_skill_threats.py": "05452f244b1c0f5259d2f45a41593c1a1b82d7caad39f6b1efb0b87f02c09729",
     "scripts/scan_splitstream.py": "4fd98a612442a8c241e8796f984e6ecce3e43be7334355bf84f2ad408f556319",
     "scripts/scan_yara.py": "0272b4de75c8af5c461bfda86287254f1be9dfd31cfa20e2ebe91a55a8a35256",
-    "scripts/session_scan.py": "e0c4c5326059733126fa3bbb00ead2adc2f0df5f43e81958f015d24918ddefe7",
+    "scripts/session_scan.py": "aa8040754b471737f2611293f0356e04955e9e66c7f9fca44d688b0d2860cc08",
     "scripts/validate_manifests.py": "a0926bc0a0b86ca59a2d66036a8bce403d4d4a0793bf799af8554e3c36ef43c9",
     "scripts/verify_install.py": "b98802487a4483f53553ef106ad82692ea92ad2b94972f73684e52d29c468034",
     "scripts/vuln_feed.py": "0b56e20969beb8fbc59650114a34ac8743d1a0862ff3ae56b07e92d2e368a141"

--- a/skills/repo-forensics/scripts/session_scan.py
+++ b/skills/repo-forensics/scripts/session_scan.py
@@ -597,7 +597,7 @@ def _is_above_report_floor(item):
     deliberate: this field is attacker-controlled -- load_scanner_results()
     copies each scanner's JSON through verbatim -- so a floor that swallowed
     off-vocabulary severities would hand a scanned repository a one-word way
-    to suppress its own worst finding, trading the false clean this reader
+    to suppress its own worst finding, trading the false-clean this reader
     exists to remove for a narrower one. It renders `UNKNOWN` and sorts below
     every ranked finding, so it can neither hide nor crowd one out.
     """
@@ -624,7 +624,7 @@ def _format_overflow_line(hidden):
     """The one line a capped report owes the reader.
 
     Truncation is silent unless it says so, and a silent truncation is the
-    same defect class as the false clean above it: a report that showed five
+    same defect class as the false-clean above it: a report that showed five
     of nine findings and looked exactly like a report that found five. The
     count and the per-severity breakdown are what make the difference visible
     without adding another line per hidden finding.
@@ -699,7 +699,7 @@ def summarize_deep_findings(report):
     it arrived: free text is sanitized, and the severity -- which is not free
     text but a four-word vocabulary -- is checked against it. That is a
     condition of the repair, not a refinement of it: reporting the findings
-    without neutralizing them would trade a false clean for an injection path
+    without neutralizing them would trade a false-clean for an injection path
     into SessionStart.
 
     What reaches the reader is then bounded twice: DEEP_FINDING_REPORT_FLOOR
@@ -806,7 +806,7 @@ def deep_scan_item(dirpath, label, item_type, timeout=None, adjudication_sink=No
     if not findings:
         # Silence is not an available answer past this point -- see
         # _format_uncleared_scan_line(). The item is reported uncleared as
-        # well as spoken about, because a false clean that gets baselined is
+        # well as spoken about, because a false-clean that gets baselined is
         # not one missed report, it is every future one.
         if uncleared_sink is not None:
             uncleared_sink.append(f"{item_type}:{dirpath}")

--- a/skills/repo-forensics/scripts/session_scan.py
+++ b/skills/repo-forensics/scripts/session_scan.py
@@ -702,14 +702,14 @@ def summarize_deep_findings(report):
     without neutralizing them would trade a false clean for an injection path
     into SessionStart.
 
-    What reaches the reader is then bounded twice, because the report competes
-    with the session for the same context window. DEEP_FINDING_REPORT_FLOOR
-    drops the notes; DEEP_FINDING_MAX_LINES bounds how many lines one item can
-    occupy. Sorting happens here rather than being taken from the report: the
-    aggregator does sort worst-first, but the report is a scanner's stdout and
-    this is the last thing between it and the user, so truncating on a trusted
-    order would let a producer decide which finding the owner never sees. The
-    sort is stable, so findings of one severity keep the order they arrived in.
+    What reaches the reader is then bounded twice: DEEP_FINDING_REPORT_FLOOR
+    drops the notes, and DEEP_FINDING_MAX_LINES bounds how many lines one item
+    can occupy -- see each constant, which explains why it is there. Sorting
+    happens here rather than being taken from the report: the aggregator does
+    sort worst-first, but the report is a scanner's stdout and this is the last
+    thing between it and the user, so truncating on a trusted order would let a
+    producer decide which finding the owner never sees. The sort is stable, so
+    findings of one severity keep the order they arrived in.
 
     Nothing here spawns a subprocess or reads the scanned tree, so the
     rendering can be exercised without one; deep_scan_item() owns the

--- a/skills/repo-forensics/scripts/session_scan.py
+++ b/skills/repo-forensics/scripts/session_scan.py
@@ -641,6 +641,29 @@ def _format_overflow_line(hidden):
     return f"... and {len(hidden)} more {noun} not shown ({breakdown})"
 
 
+def _format_uncleared_scan_line(returncode):
+    """The one line a scan owes the reader when it rendered nothing.
+
+    Reached only past the early returns for exit 0 and for a signal death, so
+    the scan ended nonzero and the reader still produced nothing: the report
+    was unparseable at a code deep_scan_item()'s own fallbacks do not cover,
+    or every finding in it sat below DEEP_FINDING_REPORT_FLOOR, or its shape
+    was not one this reader knows. All three are problems inside the tool,
+    and the owner cannot tell them apart from here -- but reporting the item
+    `clean` would tell them the one thing that is certainly false.
+
+    The exit code is in the line because it is the only handle the owner has
+    on which of those happened: 99 is an infrastructure failure, 1 and 2 are
+    findings the reader could not render. Carries no attacker-controlled text
+    -- an integer from waitpid and nothing else -- and deliberately does not
+    start with `[`, so it cannot be mistaken for a finding line.
+    """
+    return (
+        f"deep scan exited {returncode} with no reportable finding "
+        f"(not cleared; will be re-reported next session)"
+    )
+
+
 def report_findings(report):
     """The report's finding list, or empty for anything that is not one.
 
@@ -701,7 +724,8 @@ def summarize_deep_findings(report):
     return lines
 
 
-def deep_scan_item(dirpath, label, item_type, timeout=None, adjudication_sink=None):
+def deep_scan_item(dirpath, label, item_type, timeout=None, adjudication_sink=None,
+                   uncleared_sink=None):
     """Run the full run_forensics.sh scanner suite on a changed item.
 
     On POSIX, uses start_new_session=True so the entire process tree
@@ -710,7 +734,13 @@ def deep_scan_item(dirpath, label, item_type, timeout=None, adjudication_sink=No
     scanner zombies. Windows lacks os.getpgid/os.killpg, so it falls
     back to killing the direct subprocess.
 
-    Returns list of finding strings (empty = clean). Never raises.
+    Returns list of finding strings. Never raises. A scan that actually ran
+    and ended nonzero never returns an empty list: if it renders no finding it
+    returns one line naming its exit code rather than going quiet, and appends
+    the item's baseline key to *uncleared_sink* so main() can keep it out of
+    the baseline. The early returns above -- no scanner script, no such
+    directory, no time budget left, an OSError launching it -- still return []
+    and leave the sink untouched.
     """
     if not os.path.isfile(RUN_FORENSICS_SCRIPT):
         return []
@@ -771,6 +801,15 @@ def deep_scan_item(dirpath, label, item_type, timeout=None, adjudication_sink=No
             findings.append("deep scan found CRITICAL issues (parse failed, check manually)")
         elif proc.returncode == 1:
             findings.append("deep scan found warnings (parse failed, check manually)")
+
+    if not findings:
+        # Silence is not an available answer past this point -- see
+        # _format_uncleared_scan_line(). The item is reported uncleared as
+        # well as spoken about, because a false clean that gets baselined is
+        # not one missed report, it is every future one.
+        if uncleared_sink is not None:
+            uncleared_sink.append(f"{item_type}:{dirpath}")
+        findings.append(_format_uncleared_scan_line(proc.returncode))
 
     return findings
 
@@ -1021,6 +1060,7 @@ def main(argv=None):
     # Only runs when items actually changed (rare). Skipped on first run
     # (too many items) and when run_forensics.sh is missing.
     adjudication_findings = []
+    uncleared_items = []
     if scan_items and not is_first_run and os.path.isfile(RUN_FORENSICS_SCRIPT):
         deep_start = time.monotonic()
         for dirpath, label, itype, checksums in scan_items:
@@ -1033,7 +1073,8 @@ def main(argv=None):
                 break
             deep_findings = deep_scan_item(dirpath, label, itype, timeout=min(
                 DEEP_SCAN_TIMEOUT_PER_ITEM, remaining
-            ), adjudication_sink=adjudication_findings)
+            ), adjudication_sink=adjudication_findings,
+                uncleared_sink=uncleared_items)
             scan_results.setdefault(f"{itype}:{dirpath}", []).extend(deep_findings)
 
     # Format output
@@ -1059,6 +1100,16 @@ def main(argv=None):
     # detect_changes already produced fresh entries for every item; reuse them
     # directly instead of re-walking the tree. Avoids ~150-300ms of redundant
     # stat syscalls on warm sessions.
+    #
+    # An item whose deep scan ended nonzero and rendered nothing was never
+    # cleared, so it is dropped from the snapshot rather than written into it.
+    # Baselining it would silence the same result at every future session
+    # start -- detect_changes() reports only items whose hashes moved -- which
+    # turns one failure the owner could act on into a permanent one they never
+    # see again. Dropping the key costs that item its incremental-hash cache
+    # on the next run and nothing else.
+    for item_key in uncleared_items:
+        all_entries.pop(item_key, None)
     save_baseline(all_entries)
 
     output_session_context(lines, adapter=adapter)

--- a/skills/repo-forensics/scripts/session_scan.py
+++ b/skills/repo-forensics/scripts/session_scan.py
@@ -500,16 +500,17 @@ DEEP_FINDING_SEVERITIES = ("critical", "high", "medium", "low")
 
 # Severities worth a line at session start. `low` is deliberately excluded: it
 # is an informational note, and a note that turns every plugin update into a
-# warning line spends the report's credibility on nothing. A report nobody
-# reads is not a control, it is an alibi.
+# warning line trains the reader to skip the report. A skipped report is not
+# read as "nothing was said" but as "nothing was found" -- the same false-clean
+# a nonzero scan reporting nothing would be.
 #
 # A severity the vocabulary does not contain is NOT below this floor -- see
 # _is_above_report_floor(), which explains why.
 DEEP_FINDING_REPORT_FLOOR = ("critical", "high", "medium")
 
-# Finding lines one changed item may spend, before the overflow line. This
+# Finding lines one changed item may occupy, before the overflow line. This
 # return value is echoed into the agent's session context, so an uncapped
-# report from one noisy target pushes the rest of the session out of the
+# report from one finding-heavy item pushes the rest of the session out of the
 # window. The cap is lossy by construction, which is why _format_overflow_line()
 # exists: a capped report that did not say so would read as a complete one.
 DEEP_FINDING_MAX_LINES = 5
@@ -626,7 +627,7 @@ def _format_overflow_line(hidden):
     same defect class as the false clean above it: a report that showed five
     of nine findings and looked exactly like a report that found five. The
     count and the per-severity breakdown are what make the difference visible
-    without spending another line per hidden finding.
+    without adding another line per hidden finding.
 
     Carries no attacker-controlled text -- only integers and severity tags
     already checked against the vocabulary -- and deliberately does not start
@@ -703,8 +704,8 @@ def summarize_deep_findings(report):
 
     What reaches the reader is then bounded twice, because the report competes
     with the session for the same context window. DEEP_FINDING_REPORT_FLOOR
-    drops the notes; DEEP_FINDING_MAX_LINES bounds what one noisy target can
-    spend. Sorting happens here rather than being taken from the report: the
+    drops the notes; DEEP_FINDING_MAX_LINES bounds how many lines one item can
+    occupy. Sorting happens here rather than being taken from the report: the
     aggregator does sort worst-first, but the report is a scanner's stdout and
     this is the last thing between it and the user, so truncating on a trusted
     order would let a producer decide which finding the owner never sees. The

--- a/skills/repo-forensics/scripts/session_scan.py
+++ b/skills/repo-forensics/scripts/session_scan.py
@@ -481,6 +481,137 @@ def scan_item(dirpath, label, item_type, checksums):
     return findings
 
 
+# Per-field caps for a rendered finding line. The session report is echoed
+# into the agent's context, so length is bounded per field as well as per
+# line. All three are the caps this codebase already applies to the same
+# fields: title and description in aggregate_json.format_report_as_text() and
+# adjudication.build_adjudication_block(), the path in the latter -- the text
+# formatter is the odd one out and does not sanitize its path at all.
+DEEP_FINDING_TITLE_MAX = 160
+DEEP_FINDING_DESC_MAX = 300
+DEEP_FINDING_PATH_MAX = 160
+
+# The aggregator's severity vocabulary, mirrored rather than imported:
+# session_scan is a SessionStart hook on a 15s budget and deliberately imports
+# no heavy scanner module. TestDeepScanFindingsReachTheSession pins this tuple
+# against aggregate_json.SEVERITY_ORDER so the mirror cannot drift.
+DEEP_FINDING_SEVERITIES = ("critical", "high", "medium", "low")
+
+
+def _snippet_sanitizer():
+    """Return the sanitizer used for finding-derived text.
+
+    Same lazy import and same stdlib fallback aggregate_json.format_report_as_text()
+    uses for the same fields, so there is one neutralization behaviour in this
+    codebase rather than two that can drift. The fallback's character ranges are
+    that formatter's, written as escapes: C0/C1 controls plus the BIDI
+    overrides (U+202A-U+202E) and isolates (U+2066-U+2069).
+    """
+    try:
+        import adjudication as _adj
+        return _adj.sanitize_snippet
+    except ImportError:
+        import re as _re
+
+        def _sanitize(text, max_len=300):
+            if not isinstance(text, str):
+                return ""
+            cleaned = _re.sub(
+                "[\x00-\x1f\x7f\x80-\x9f\u202a-\u202e\u2066-\u2069]", "", text
+            )
+            cleaned = _re.sub(r"\s+", " ", cleaned).strip()
+            return cleaned[:max_len]
+
+        return _sanitize
+
+
+def _format_finding_location(item, sanitize):
+    """`file:line` for a finding, or `file` when the scanner gave no line."""
+    path = sanitize(item.get("file") or "", max_len=DEEP_FINDING_PATH_MAX)
+    if not path:
+        return "location unknown"
+    try:
+        line_no = int(item.get("line") or 0)
+    except (TypeError, ValueError):
+        line_no = 0
+    return f"{path}:{line_no}" if line_no > 0 else path
+
+
+def _format_finding_severity(item):
+    """The finding's severity tag, or `UNKNOWN` for anything off-vocabulary.
+
+    Checked against the vocabulary rather than sanitized. Nothing downstream
+    validates this field -- load_scanner_results() copies each scanner's JSON
+    through verbatim -- so a scanned repository controls it exactly as it
+    controls the title, and a severity of "high\n[CRITICAL] ..." would forge a
+    top-level line. Sanitizing would neutralize that; refusing the value
+    outright also refuses to show the reader a severity the aggregator cannot
+    rank, which is the more honest failure.
+    """
+    severity = item.get("severity")
+    if isinstance(severity, str) and severity.lower() in DEEP_FINDING_SEVERITIES:
+        return severity.upper()
+    return "UNKNOWN"
+
+
+def _format_finding_line(item, sanitize):
+    """One display line: severity, what was found, where, and why it matters."""
+    title = sanitize(item.get("title") or "", max_len=DEEP_FINDING_TITLE_MAX)
+    description = sanitize(item.get("description") or "", max_len=DEEP_FINDING_DESC_MAX)
+    line = (
+        f"[{_format_finding_severity(item)}] {title or 'untitled finding'} "
+        f"({_format_finding_location(item, sanitize)})"
+    )
+    if description:
+        line += f" - {description}"
+    return line
+
+
+def report_findings(report):
+    """The report's finding list, or empty for anything that is not one.
+
+    Both readers of `report["findings"]` go through here, and the type checks
+    are load-bearing rather than defensive habit: the report is parsed from a
+    scanner's stdout, so any field can be any JSON type, and `for item in 5`
+    raises a TypeError that deep_scan_item()'s
+    `except (json.JSONDecodeError, ValueError)` does not catch -- breaking its
+    documented promise never to raise, and taking the SessionStart hook with
+    it.
+    """
+    if not isinstance(report, dict):
+        return []
+    items = report.get("findings")
+    if not isinstance(items, (list, tuple)):
+        return []
+    return [item for item in items if isinstance(item, dict)]
+
+
+def summarize_deep_findings(report):
+    """Render a parsed aggregate report's findings as session display lines.
+
+    Severity is read from each finding, because that is the only place the
+    aggregator puts one. An entry of `report["scanners"]` carries exactly
+    `name`, `exit_code`, `parse_error`, `finding_count`, `findings`, plus
+    `stderr` when present -- never a severity. A reader that looked for one
+    there collected nothing and printed `clean` over a scan that exited 2 on a
+    CRITICAL finding, which is the defect this function exists to fix.
+
+    Every rendered field originates in the scanned tree and this return value
+    is echoed into the agent's session context, so none of it is rendered as
+    it arrived: free text is sanitized, and the severity -- which is not free
+    text but a four-word vocabulary -- is checked against it. That is a
+    condition of the repair, not a refinement of it: reporting the findings
+    without neutralizing them would trade a false clean for an injection path
+    into SessionStart.
+
+    Nothing here spawns a subprocess or reads the scanned tree, so the
+    rendering can be exercised without one; deep_scan_item() owns the
+    subprocess and hands the parsed report in.
+    """
+    sanitize = _snippet_sanitizer()
+    return [_format_finding_line(item, sanitize) for item in report_findings(report)]
+
+
 def deep_scan_item(dirpath, label, item_type, timeout=None, adjudication_sink=None):
     """Run the full run_forensics.sh scanner suite on a changed item.
 
@@ -538,21 +669,13 @@ def deep_scan_item(dirpath, label, item_type, timeout=None, adjudication_sink=No
     try:
         data = json.loads(stdout)
         if isinstance(data, dict):
-            for scanner in data.get('scanners', []):
-                if not isinstance(scanner, dict):
-                    continue
-                sev = scanner.get('severity', '')
-                if sev in ('critical', 'high', 'warning'):
-                    scanner_name = scanner.get('name', 'unknown')
-                    detail = scanner.get('detail', scanner.get('message', ''))
-                    if detail:
-                        findings.append(f"[{sev.upper()}] {scanner_name}: {detail}")
+            findings.extend(summarize_deep_findings(data))
             # Collect WARN-tier findings flagged for adjudication (U8). These
             # carry needs_adjudication=true from aggregate_json; they feed the
             # injection-safe adjudication block built once in main().
             if adjudication_sink is not None:
-                for finding in data.get('findings', []):
-                    if isinstance(finding, dict) and finding.get('needs_adjudication') is True:
+                for finding in report_findings(data):
+                    if finding.get('needs_adjudication') is True:
                         adjudication_sink.append(finding)
     except (json.JSONDecodeError, ValueError):
         if proc.returncode == 2:

--- a/skills/repo-forensics/scripts/session_scan.py
+++ b/skills/repo-forensics/scripts/session_scan.py
@@ -494,8 +494,25 @@ DEEP_FINDING_PATH_MAX = 160
 # The aggregator's severity vocabulary, mirrored rather than imported:
 # session_scan is a SessionStart hook on a 15s budget and deliberately imports
 # no heavy scanner module. TestDeepScanFindingsReachTheSession pins this tuple
-# against aggregate_json.SEVERITY_ORDER so the mirror cannot drift.
+# against aggregate_json.SEVERITY_ORDER so the mirror cannot drift -- its
+# members and, since the reader sorts by position in it, its order.
 DEEP_FINDING_SEVERITIES = ("critical", "high", "medium", "low")
+
+# Severities worth a line at session start. `low` is deliberately excluded: it
+# is an informational note, and a note that turns every plugin update into a
+# warning line spends the report's credibility on nothing. A report nobody
+# reads is not a control, it is an alibi.
+#
+# A severity the vocabulary does not contain is NOT below this floor -- see
+# _is_above_report_floor(), which explains why.
+DEEP_FINDING_REPORT_FLOOR = ("critical", "high", "medium")
+
+# Finding lines one changed item may spend, before the overflow line. This
+# return value is echoed into the agent's session context, so an uncapped
+# report from one noisy target pushes the rest of the session out of the
+# window. The cap is lossy by construction, which is why _format_overflow_line()
+# exists: a capped report that did not say so would read as a complete one.
+DEEP_FINDING_MAX_LINES = 5
 
 
 def _snippet_sanitizer():
@@ -554,6 +571,41 @@ def _format_finding_severity(item):
     return "UNKNOWN"
 
 
+def _severity_rank(item):
+    """Sort key for a finding: 0 is worst.
+
+    Position in DEEP_FINDING_SEVERITIES, which is the aggregator's ranking
+    mirrored worst-first. Anything off the vocabulary ranks after every known
+    severity, so an unrankable value cannot be used to claim the top of a
+    capped report.
+    """
+    severity = item.get("severity")
+    if isinstance(severity, str):
+        try:
+            return DEEP_FINDING_SEVERITIES.index(severity.lower())
+        except ValueError:
+            pass
+    return len(DEEP_FINDING_SEVERITIES)
+
+
+def _is_above_report_floor(item):
+    """Is this finding worth one of the session report's lines?
+
+    A recognized severity is tested against DEEP_FINDING_REPORT_FLOOR. An
+    unrecognized one is reported instead of dropped, and that asymmetry is
+    deliberate: this field is attacker-controlled -- load_scanner_results()
+    copies each scanner's JSON through verbatim -- so a floor that swallowed
+    off-vocabulary severities would hand a scanned repository a one-word way
+    to suppress its own worst finding, trading the false clean this reader
+    exists to remove for a narrower one. It renders `UNKNOWN` and sorts below
+    every ranked finding, so it can neither hide nor crowd one out.
+    """
+    severity = item.get("severity")
+    if isinstance(severity, str) and severity.lower() in DEEP_FINDING_SEVERITIES:
+        return severity.lower() in DEEP_FINDING_REPORT_FLOOR
+    return True
+
+
 def _format_finding_line(item, sanitize):
     """One display line: severity, what was found, where, and why it matters."""
     title = sanitize(item.get("title") or "", max_len=DEEP_FINDING_TITLE_MAX)
@@ -565,6 +617,28 @@ def _format_finding_line(item, sanitize):
     if description:
         line += f" - {description}"
     return line
+
+
+def _format_overflow_line(hidden):
+    """The one line a capped report owes the reader.
+
+    Truncation is silent unless it says so, and a silent truncation is the
+    same defect class as the false clean above it: a report that showed five
+    of nine findings and looked exactly like a report that found five. The
+    count and the per-severity breakdown are what make the difference visible
+    without spending another line per hidden finding.
+
+    Carries no attacker-controlled text -- only integers and severity tags
+    already checked against the vocabulary -- and deliberately does not start
+    with `[`, so it cannot be mistaken for one more finding line.
+    """
+    counts = {}
+    for item in sorted(hidden, key=_severity_rank):
+        tag = _format_finding_severity(item)
+        counts[tag] = counts.get(tag, 0) + 1
+    breakdown = ", ".join(f"{count} {tag}" for tag, count in counts.items())
+    noun = "finding" if len(hidden) == 1 else "findings"
+    return f"... and {len(hidden)} more {noun} not shown ({breakdown})"
 
 
 def report_findings(report):
@@ -604,12 +678,27 @@ def summarize_deep_findings(report):
     without neutralizing them would trade a false clean for an injection path
     into SessionStart.
 
+    What reaches the reader is then bounded twice, because the report competes
+    with the session for the same context window. DEEP_FINDING_REPORT_FLOOR
+    drops the notes; DEEP_FINDING_MAX_LINES bounds what one noisy target can
+    spend. Sorting happens here rather than being taken from the report: the
+    aggregator does sort worst-first, but the report is a scanner's stdout and
+    this is the last thing between it and the user, so truncating on a trusted
+    order would let a producer decide which finding the owner never sees. The
+    sort is stable, so findings of one severity keep the order they arrived in.
+
     Nothing here spawns a subprocess or reads the scanned tree, so the
     rendering can be exercised without one; deep_scan_item() owns the
     subprocess and hands the parsed report in.
     """
     sanitize = _snippet_sanitizer()
-    return [_format_finding_line(item, sanitize) for item in report_findings(report)]
+    items = [item for item in report_findings(report) if _is_above_report_floor(item)]
+    items.sort(key=_severity_rank)
+    shown, hidden = items[:DEEP_FINDING_MAX_LINES], items[DEEP_FINDING_MAX_LINES:]
+    lines = [_format_finding_line(item, sanitize) for item in shown]
+    if hidden:
+        lines.append(_format_overflow_line(hidden))
+    return lines
 
 
 def deep_scan_item(dirpath, label, item_type, timeout=None, adjudication_sink=None):

--- a/skills/repo-forensics/tests/report_builders.py
+++ b/skills/repo-forensics/tests/report_builders.py
@@ -1,0 +1,125 @@
+"""Report-shaped test data, built by the product's own emitters.
+
+Nothing here hand-writes a report. ``finding()`` goes through
+``forensics_core.Finding``, the dataclass scanner findings are emitted
+through, and ``aggregate_report()`` drives
+``aggregate_json.load_scanner_results()`` -- the same loader
+``build_report()`` uses -- over scanner output files written the way
+``run_forensics.sh`` writes them.
+
+That is the whole point of the module. A hand-written fixture records what
+its author believed the report looks like, and stays green while the product
+drifts away from it: the SessionStart deep scan read a scanner-level
+``severity`` key that the aggregator has never emitted, and the suite passed
+throughout while CRITICAL findings were dropped. Test data built by the
+emitter cannot describe a shape the product does not produce.
+
+``aggregate_report()`` stops at the loader plus the two pure functions that
+score its output (``build_summary``, ``calculate_report_exit_code``) rather
+than calling ``build_report()`` end to end. ``build_report()`` also runs
+correlation, raw trifecta detection, suppression and evidence capping, each
+of which adds to or rewrites the finding set by reading the target from
+disk -- a fixture whose findings change under it is not a fixture.
+``TestAggregateReportContract`` in ``test_session_scan.py`` pins the two
+against each other so that shortcut cannot become a drift of its own.
+"""
+
+import json
+import os
+
+import aggregate_json
+import forensics_core
+
+
+def finding(severity="high", **overrides):
+    """One finding dict, shaped as scanners emit them.
+
+    Built through ``forensics_core.Finding`` so the key set, the defaults and
+    the ``__post_init__`` coercions (severity lowercasing, confidence fill,
+    evidence class, ``finding_id``) are the product's rather than a test
+    author's. Any field of the dataclass may be overridden by keyword.
+    """
+    fields = {
+        "scanner": "skill_threats",
+        "severity": severity,
+        "title": "Test Finding",
+        "description": "A finding built for a test.",
+        "file": "evil.py",
+        "line": 1,
+        "snippet": "exec(payload)",
+        "category": "injection",
+    }
+    fields.update(overrides)
+    return forensics_core.Finding(**fields).to_dict()
+
+
+def _exit_code_for(findings):
+    """run_forensics.sh's per-scanner exit contract, applied as a default.
+
+    0 clean, 1 high/medium, 2 critical, 99 infrastructure failure. Callers
+    that are testing the exit code pass one explicitly; this only spares the
+    rest from restating the contract at every call site.
+    """
+    severities = {item.get("severity") for item in findings}
+    if "critical" in severities:
+        return 2
+    if severities & {"high", "medium"}:
+        return 1
+    return 0
+
+
+def scanner_result(name, findings=(), exit_code=None, stderr=""):
+    """Describe one scanner's raw output for ``aggregate_report()``."""
+    findings = list(findings)
+    return {
+        "name": name,
+        "findings": findings,
+        "exit_code": _exit_code_for(findings) if exit_code is None else exit_code,
+        "stderr": stderr,
+    }
+
+
+def write_scanner_results(dirpath, results):
+    """Write the ``.out`` / ``.err`` / ``.exit`` trio run_forensics.sh writes.
+
+    This is the input side of the loader's contract: the aggregator reads
+    these three files per scanner and nothing else.
+    """
+    os.makedirs(dirpath, exist_ok=True)
+    for result in results:
+        base = os.path.join(str(dirpath), result["name"])
+        with open(base + ".out", "w", encoding="utf-8") as handle:
+            json.dump(result["findings"], handle)
+        with open(base + ".err", "w", encoding="utf-8") as handle:
+            handle.write(result["stderr"])
+        with open(base + ".exit", "w", encoding="utf-8") as handle:
+            handle.write(str(result["exit_code"]))
+    return str(dirpath)
+
+
+def aggregate_report(dirpath, results, target="/repo", mode="full"):
+    """An aggregate report, assembled by the aggregator's own functions.
+
+    ``dirpath`` is a scratch directory the scanner output files are written
+    into; ``results`` is a sequence of ``scanner_result()`` dicts. The
+    returned report's ``scanners`` and ``findings`` come straight out of
+    ``load_scanner_results()``, its ``summary`` out of ``build_summary()``
+    and its ``exit_code`` out of ``calculate_report_exit_code()``.
+    """
+    write_scanner_results(dirpath, results)
+    scanners, findings = aggregate_json.load_scanner_results(str(dirpath))
+    # Mirrors build_report(): worst first, so a reader that shows only the
+    # top N sees the same order it would in a real report.
+    findings.sort(
+        key=lambda item: -aggregate_json.SEVERITY_ORDER.get(item.get("severity", "low"), 0)
+    )
+    summary = aggregate_json.build_summary(findings)
+    return {
+        "target": target,
+        "mode": mode,
+        "scanner_count": len(scanners),
+        "scanners": scanners,
+        "summary": summary,
+        "exit_code": aggregate_json.calculate_report_exit_code(summary, scanners),
+        "findings": findings,
+    }

--- a/skills/repo-forensics/tests/test_session_scan.py
+++ b/skills/repo-forensics/tests/test_session_scan.py
@@ -1058,8 +1058,10 @@ class TestDeepScanFindingsReachTheSession:
         scanner-level `severity`/`detail`, so nothing in this payload is a
         finding and none of it may be rendered as one.
 
-        Whether such a scan is still allowed to report the item *clean* is
-        ticket 04's question, not this one.
+        Whether such a scan is still allowed to report the item *clean* is a
+        separate question, answered by
+        `TestNonzeroScanSpeaksInsteadOfGoingQuiet.test_the_invented_report_shape_is_not_read_as_clean`:
+        it is not.
         """
         payload = {
             "summary": {"critical": 1},
@@ -1325,6 +1327,272 @@ class TestSessionReportFrictionBudget:
         assert len(shown) == 2
         assert shown[0].startswith("[MEDIUM]")
         assert shown[1].startswith("[UNKNOWN]")
+
+
+# ========================================================================
+# Ticket 04: a nonzero scan that renders nothing says so, and is not cleared
+# ========================================================================
+
+def session_start(monkeypatch, capsys):
+    """One SessionStart run of the hook. Returns what it printed.
+
+    `main()` is the only entry point that writes the baseline, so the
+    baseline half of this behaviour cannot be observed anywhere below it.
+    """
+    monkeypatch.setattr(session_scan, 'refresh_threat_databases', lambda: [])
+    monkeypatch.delenv("REPO_FORENSICS_SESSION_SCAN", raising=False)
+    with pytest.raises(SystemExit) as exc:
+        session_scan.main()
+    assert exc.value.code == 0
+    return capsys.readouterr().out
+
+
+def baselined_items():
+    """The item keys the saved baseline currently holds."""
+    with open(session_scan.BASELINE_FILE, "r", encoding="utf-8") as handle:
+        return set(json.load(handle).get("items", {}))
+
+
+def change_plugin(plugin_dir, content):
+    """Move a plugin's content so the next run sees it as changed."""
+    with open(os.path.join(plugin_dir, "index.js"), "w", encoding="utf-8") as handle:
+        handle.write(content)
+
+
+@_POSIX_ONLY
+class TestNonzeroScanSpeaksInsteadOfGoingQuiet:
+    """A scan that ended nonzero and rendered nothing says exactly that.
+
+    This is the one deliberate behaviour change in this work, and it is a
+    change rather than a fix: a deep scan ending in 99 previously returned no
+    lines at all, so `format_output()` printed `clean` over it. A shape
+    problem inside the tool reached the owner disguised as a clean item --
+    the same false clean the rest of this spine removes, arriving through the
+    reader's silence rather than through its blindness.
+
+    Every early return above this point has already handled the two cases
+    that legitimately render nothing: exit 0, which is the scanner saying it
+    found nothing, and a signal death, which already speaks for itself.
+    Reaching the end with an empty list past both of them means the aggregate
+    carried something the reader could not turn into a line.
+
+    Assertions are on what `deep_scan_item()` returns and on what
+    `format_output()` prints. The baseline is a separate subject and lives in
+    `TestAnUnclearedItemStaysOutOfTheBaseline`, one seam up, because
+    `deep_scan_item()` does not write it.
+    """
+
+    def test_a_nonzero_scan_that_renders_nothing_names_its_exit_code(
+        self, tmp_dir, tmp_path, monkeypatch
+    ):
+        """Exit 99 with an empty report: the infrastructure-failure case."""
+        report = aggregate_report(tmp_path, [
+            scanner_result("skill_threats", [], exit_code=0),
+        ])
+        stub_forensics(tmp_dir, monkeypatch, report, 99)
+
+        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
+
+        assert len(findings) == 1
+        assert "99" in findings[0]
+        # Not a finding line: it reports the scan, not something found in the
+        # tree, and must not be mistakable for one.
+        assert rendered_findings(findings) == []
+
+    def test_the_item_is_never_reported_as_clean(self, tmp_dir, tmp_path, monkeypatch):
+        """Driven through the function that produces the word `clean`.
+
+        A line the reader emitted that the formatter then ignored would still
+        be a false clean on the owner's screen, so the assertion is made where
+        the word is written rather than one seam below it.
+        """
+        report = aggregate_report(tmp_path, [
+            scanner_result("skill_threats", [], exit_code=0),
+        ])
+        stub_forensics(tmp_dir, monkeypatch, report, 99)
+        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
+
+        lines = session_scan.format_output(
+            [], [(tmp_dir, "test-plugin", "plugin", {})],
+            {f"plugin:{tmp_dir}": findings}, False, 1,
+        )
+
+        assert not any("clean" in line for line in lines)
+        assert not any("Security check passed" in line for line in lines)
+        assert any("99" in line for line in lines)
+
+    def test_the_invented_report_shape_is_not_read_as_clean(self, tmp_dir, monkeypatch):
+        """The other half of `test_invented_report_shape_is_not_read_as_findings`.
+
+        That test pins that nothing in this payload is rendered as a finding.
+        The question it left open -- whether a scan carrying it may still
+        report the item clean -- is answered here: it may not. Same
+        hand-written shape, at the exit code the defect was first seen at.
+        """
+        payload = {
+            "summary": {"critical": 1},
+            "scanners": [
+                {"name": "runtime_behavior", "severity": "critical",
+                 "detail": "eval() with external input detected"},
+            ],
+        }
+        stub_forensics(tmp_dir, monkeypatch, payload, 2)
+
+        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
+
+        assert len(findings) == 1
+        assert "2" in findings[0]
+        assert not any("eval() with external input" in line for line in findings)
+
+    def test_a_report_below_the_floor_still_surfaces_its_nonzero_exit(
+        self, tmp_dir, tmp_path, monkeypatch
+    ):
+        """The silence ticket 03 opened by dropping LOW below the floor.
+
+        Reachable rather than theoretical: an unexpected scanner exit code
+        becomes a `parse_error`, and `calculate_report_exit_code()` returns 99
+        on any `parse_error` whatever the findings say. So a report whose only
+        finding is a note can still end nonzero, and the reader renders
+        nothing from it.
+        """
+        report = aggregate_report(tmp_path, [
+            scanner_result("skill_threats", [
+                finding(severity="low", title="Informational note"),
+            ], exit_code=7),
+        ])
+        # The premise of the assertions below, not an incidental property: the
+        # report really does end nonzero, and its only finding really is a note.
+        assert report["exit_code"] == 99
+        assert [item["severity"] for item in report["findings"]] == ["low"]
+        stub_forensics(tmp_dir, monkeypatch, report, 99)
+
+        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
+
+        assert rendered_findings(findings) == []
+        assert len(findings) == 1
+        assert "99" in findings[0]
+        assert "Informational note" not in findings[0]
+
+    def test_a_clean_exit_stays_silent_even_when_nothing_is_rendered(
+        self, tmp_dir, tmp_path, monkeypatch
+    ):
+        """Exit 0 is the scanner saying it found nothing, and is still believed.
+
+        The sharp version of "the existing early returns keep their
+        behaviour": this report carries a LOW finding, so the reader renders
+        nothing from it either -- but the exit code is 0, so this is not the
+        silence the new line exists to break, and adding a line here would
+        turn every note into a warning.
+        """
+        report = aggregate_report(tmp_path, [
+            scanner_result("skill_threats", [
+                finding(severity="low", title="Informational note"),
+            ], exit_code=0),
+        ])
+        assert report["exit_code"] == 0
+        stub_forensics(tmp_dir, monkeypatch, report, 0)
+
+        assert session_scan.deep_scan_item(tmp_dir, "test", "plugin") == []
+
+    def test_a_signal_death_keeps_its_own_line(self, tmp_dir, monkeypatch):
+        """A killed scan already says so, and must not say it twice."""
+        script = os.path.join(tmp_dir, "stub_forensics.sh")
+        create_file(script, '#!/bin/bash\nkill -TERM $$\n')
+        os.chmod(script, 0o755)
+        monkeypatch.setattr(session_scan, 'RUN_FORENSICS_SCRIPT', script)
+
+        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
+
+        assert findings == ["deep scan killed by signal 15"]
+
+
+@_POSIX_ONLY
+class TestAnUnclearedItemStaysOutOfTheBaseline:
+    """A silent failure is not made permanent by the next run.
+
+    The baseline is what makes a session report stop repeating: `main()`
+    writes every scanned item's checksums and `detect_changes()` then reports
+    only items whose hashes moved. That is right for an item that was looked
+    at and found clean, and wrong for one whose scan ended nonzero and
+    rendered nothing -- baselining that one turns a single silent failure into
+    a permanent one, because the same result is not reported at the next
+    session start either.
+
+    Driven through `main()`, the only place the baseline is written.
+    """
+
+    def _stub_scan(self, tmp_path, monkeypatch, exit_code):
+        """A stub scanner emitting an emitter-built empty report at *exit_code*.
+
+        The report goes through `aggregate_report()` like every other fixture
+        in this file rather than being written by hand: `report_builders`
+        exists precisely so no test can describe a shape the product does not
+        emit, and an empty report is one call away. What is under test here is
+        the exit code, not the report.
+        """
+        stub_forensics(str(tmp_path), monkeypatch, aggregate_report(tmp_path, []), exit_code)
+
+    def _changed_plugin(self, mock_home, monkeypatch, capsys):
+        """A plugin already in the baseline, then changed. Returns its dir and key."""
+        plugin_cache = os.path.join(mock_home, ".claude", "plugins", "cache")
+        plugin_dir = create_plugin(plugin_cache, "test-plugin")
+        session_start(monkeypatch, capsys)
+        item_key = f"plugin:{plugin_dir}"
+        # Control arm for every assertion below: the first run really does
+        # baseline this item, so "absent from the baseline" cannot pass
+        # because nothing is ever written there.
+        assert item_key in baselined_items()
+        change_plugin(plugin_dir, "// CHANGED")
+        return plugin_dir, item_key
+
+    def test_the_uncleared_item_is_not_written_into_the_baseline(
+        self, mock_home, tmp_path, monkeypatch, capsys
+    ):
+        _, item_key = self._changed_plugin(mock_home, monkeypatch, capsys)
+        self._stub_scan(tmp_path, monkeypatch, 99)
+
+        out = session_start(monkeypatch, capsys)
+
+        assert "99" in out
+        assert "clean" not in out
+        assert item_key not in baselined_items()
+
+    def test_the_same_result_surfaces_again_at_the_next_session_start(
+        self, mock_home, tmp_path, monkeypatch, capsys
+    ):
+        """Nothing moves on disk between the two runs, and it still re-reports.
+
+        That is the whole value of leaving it unbaselined: the owner sees the
+        failure again next session instead of once and never again.
+        """
+        self._changed_plugin(mock_home, monkeypatch, capsys)
+        self._stub_scan(tmp_path, monkeypatch, 99)
+        session_start(monkeypatch, capsys)
+
+        out = session_start(monkeypatch, capsys)
+
+        assert "Updates detected" in out
+        assert "99" in out
+
+    def test_an_item_that_really_was_cleared_is_still_baselined(
+        self, mock_home, tmp_path, monkeypatch, capsys
+    ):
+        """The control arm, and the behaviour that must not regress.
+
+        A scan that exited 0 cleared the item, so it is baselined and stops
+        being reported. Without this, "uncleared items are absent from the
+        baseline" would also pass on a change that stopped baselining
+        anything, and every session would re-report every changed item
+        forever.
+        """
+        _, item_key = self._changed_plugin(mock_home, monkeypatch, capsys)
+        self._stub_scan(tmp_path, monkeypatch, 0)
+
+        out = session_start(monkeypatch, capsys)
+        assert "clean" in out
+        assert item_key in baselined_items()
+
+        assert "Updates detected" not in session_start(monkeypatch, capsys)
 
 
 class TestAggregateReportContract:

--- a/skills/repo-forensics/tests/test_session_scan.py
+++ b/skills/repo-forensics/tests/test_session_scan.py
@@ -1104,16 +1104,16 @@ def unsorted_report(tmp_path, findings, exit_code=2):
     return report
 
 
-class TestSessionReportFrictionBudget:
-    """The session report is spent only on what could change what the owner does.
+class TestSessionReportIsBounded:
+    """The session report carries only what could change what the owner does.
 
-    Two costs are bounded here, and they are different costs. The **floor**
-    bounds what is worth a line at all: an informational note must not turn
-    every plugin update into a warning line, or the report stops being read,
-    and an ignored report is an alibi rather than a control. The **cap** bounds
-    what one noisy target can spend: the return value of this hook is echoed
-    into the agent's session context, so a report with no ceiling pushes the
-    rest of the session out of the window.
+    Two limits are asserted here, and they bound different things. The
+    **floor** bounds what is worth a line at all: an informational note must
+    not turn every plugin update into a warning line, or the report stops
+    being read, and a report that is not read reports nothing. The **cap**
+    bounds how many lines one item can occupy: the return value of this hook
+    is echoed into the agent's session context, so a report with no ceiling
+    pushes the rest of the session out of the window.
 
     Both are lossy, so both are made visible: a capped report says how much it
     is hiding and at what severities, and the reader sorts before it truncates
@@ -1149,7 +1149,7 @@ class TestSessionReportFrictionBudget:
         )
 
     def test_a_low_only_report_produces_no_finding_lines(self, tmp_dir, tmp_path, monkeypatch):
-        """LOW is a note, and a note is not worth a line in this budget."""
+        """LOW is a note, and a note is not worth a line at session start."""
         report = aggregate_report(tmp_path, [
             scanner_result("skill_threats", [
                 finding(severity="low", title="Informational note"),

--- a/skills/repo-forensics/tests/test_session_scan.py
+++ b/skills/repo-forensics/tests/test_session_scan.py
@@ -1286,7 +1286,7 @@ class TestSessionReportIsBounded:
         report -- a scanner's raw JSON is, and `load_scanner_results()` copies
         it through verbatim. If an unrecognised severity fell below the floor,
         a scanned repository could suppress its own worst finding by writing
-        one, trading the false clean this work removes for a narrower one.
+        one, trading the false-clean this work removes for a narrower one.
         """
         payload = {"scanners": [], "findings": [
             {"severity": "sev-9", "title": "unrankable finding",
@@ -1365,7 +1365,7 @@ class TestNonzeroScanSpeaksInsteadOfGoingQuiet:
     change rather than a fix: a deep scan ending in 99 previously returned no
     lines at all, so `format_output()` printed `clean` over it. A shape
     problem inside the tool reached the owner disguised as a clean item --
-    the same false clean the rest of this spine removes, arriving through the
+    the same false-clean the rest of this spine removes, arriving through the
     reader's silence rather than through its blindness.
 
     Every early return above this point has already handled the two cases
@@ -1401,7 +1401,7 @@ class TestNonzeroScanSpeaksInsteadOfGoingQuiet:
         """Driven through the function that produces the word `clean`.
 
         A line the reader emitted that the formatter then ignored would still
-        be a false clean on the owner's screen, so the assertion is made where
+        be a false-clean on the owner's screen, so the assertion is made where
         the word is written rather than one seam below it.
         """
         report = aggregate_report(tmp_path, [
@@ -1536,8 +1536,8 @@ class TestAnUnclearedItemStaysOutOfTheBaseline:
         plugin_dir = create_plugin(plugin_cache, "test-plugin")
         session_start(monkeypatch, capsys)
         item_key = f"plugin:{plugin_dir}"
-        # Control arm for every assertion below: the first run really does
-        # baseline this item, so "absent from the baseline" cannot pass
+        # Positive control for every assertion below: the first run really
+        # does baseline this item, so "absent from the baseline" cannot pass
         # because nothing is ever written there.
         assert item_key in baselined_items()
         change_plugin(plugin_dir, "// CHANGED")
@@ -1575,7 +1575,7 @@ class TestAnUnclearedItemStaysOutOfTheBaseline:
     def test_an_item_that_really_was_cleared_is_still_baselined(
         self, mock_home, tmp_path, monkeypatch, capsys
     ):
-        """The control arm, and the behaviour that must not regress.
+        """The positive control, and the behaviour that must not regress.
 
         A scan that exited 0 cleared the item, so it is baselined and stops
         being reported. Without this, "uncleared items are absent from the
@@ -1607,7 +1607,7 @@ class TestAggregateReportContract:
     Every assertion here is on the emitter's own output, so the class is green
     on the unchanged base commit and goes red the moment the emitted shape
     moves under a reader still expecting the old one. That is what makes it a
-    control arm: a reader that has stopped seeing findings must not be
+    positive control: a reader that has stopped seeing findings must not be
     indistinguishable from a target that has none.
     """
 

--- a/skills/repo-forensics/tests/test_session_scan.py
+++ b/skills/repo-forensics/tests/test_session_scan.py
@@ -1076,6 +1076,257 @@ class TestDeepScanFindingsReachTheSession:
         assert not any("runtime_behavior" in line for line in findings)
 
 
+def rendered_findings(lines):
+    """The severity-tagged lines: every rendered finding starts with `[`."""
+    return [line for line in lines if line.startswith("[")]
+
+
+def overflow_lines(lines):
+    """Everything the renderer emitted that is not a finding line."""
+    return [line for line in lines if not line.startswith("[")]
+
+
+def unsorted_report(tmp_path, findings, exit_code=2):
+    """An emitter-built report whose finding order is deliberately wrong.
+
+    `aggregate_report()` sorts worst-first because `build_report()` does. The
+    reader may not rely on that: the report is a scanner's stdout, and the
+    reader is the last thing between it and the user. Reversing the list is
+    what makes "sorted in the reader" an assertion rather than a coincidence
+    inherited from the producer.
+    """
+    report = aggregate_report(tmp_path, [
+        scanner_result("skill_threats", findings, exit_code=exit_code),
+    ])
+    report["findings"].reverse()
+    return report
+
+
+class TestSessionReportFrictionBudget:
+    """The session report is spent only on what could change what the owner does.
+
+    Two costs are bounded here, and they are different costs. The **floor**
+    bounds what is worth a line at all: an informational note must not turn
+    every plugin update into a warning line, or the report stops being read,
+    and an ignored report is an alibi rather than a control. The **cap** bounds
+    what one noisy target can spend: the return value of this hook is echoed
+    into the agent's session context, so a report with no ceiling pushes the
+    rest of the session out of the window.
+
+    Both are lossy, so both are made visible: a capped report says how much it
+    is hiding and at what severities, and the reader sorts before it truncates
+    so what survives the cut is the worst of what was found.
+
+    Assertions are on what `deep_scan_item()` returns. Nothing here reaches
+    past it into the renderer.
+    """
+
+    def test_reporting_floor_is_the_vocabulary_minus_low(self):
+        """The floor is a named constant, and `low` is the only thing under it.
+
+        Written against the vocabulary rather than as a second literal, so a
+        severity added upstream lands above the floor by default -- reported
+        and argued about -- instead of being silently dropped by a floor that
+        was spelled out once and never revisited.
+        """
+        assert session_scan.DEEP_FINDING_REPORT_FLOOR == ("critical", "high", "medium")
+        assert (set(session_scan.DEEP_FINDING_REPORT_FLOOR)
+                == set(session_scan.DEEP_FINDING_SEVERITIES) - {"low"})
+
+    def test_severity_vocabulary_is_ordered_worst_first(self):
+        """The mirror carries the aggregator's *ranking*, not just its members.
+
+        `test_severity_vocabulary_matches_the_aggregator` pins the set. The
+        reader now sorts by position in this tuple, so its order became
+        load-bearing too: a vocabulary that drifted into a different order
+        would silently invert the truncation and hide the worst result.
+        """
+        assert list(session_scan.DEEP_FINDING_SEVERITIES) == sorted(
+            aggregate_json.SEVERITY_ORDER,
+            key=lambda severity: -aggregate_json.SEVERITY_ORDER[severity],
+        )
+
+    def test_a_low_only_report_produces_no_finding_lines(self, tmp_dir, tmp_path, monkeypatch):
+        """LOW is a note, and a note is not worth a line in this budget."""
+        report = aggregate_report(tmp_path, [
+            scanner_result("skill_threats", [
+                finding(severity="low", title="Informational note"),
+                finding(severity="low", title="Second note"),
+            ], exit_code=1),
+        ])
+        stub_forensics(tmp_dir, monkeypatch, report, 1)
+
+        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
+
+        assert rendered_findings(findings) == []
+        assert not any("Informational note" in line for line in findings)
+
+    def test_low_is_dropped_while_the_floor_is_reported(self, tmp_dir, tmp_path, monkeypatch):
+        """The floor is a filter on a mixed report, not only on an all-LOW one."""
+        report = aggregate_report(tmp_path, [
+            scanner_result("skill_threats", [
+                finding(severity="critical", title="Critical one"),
+                finding(severity="high", title="High one"),
+                finding(severity="medium", title="Medium one"),
+                finding(severity="low", title="Low one"),
+            ], exit_code=2),
+        ])
+        stub_forensics(tmp_dir, monkeypatch, report, 2)
+
+        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
+
+        assert len(rendered_findings(findings)) == 3
+        assert not any("Low one" in line for line in findings)
+        for title in ("Critical one", "High one", "Medium one"):
+            assert any(title in line for line in findings)
+
+    def test_at_most_five_finding_lines_from_one_changed_item(
+        self, tmp_dir, tmp_path, monkeypatch
+    ):
+        report = aggregate_report(tmp_path, [
+            scanner_result("skill_threats", [
+                finding(severity="high", title=f"Finding {n}") for n in range(9)
+            ], exit_code=1),
+        ])
+        stub_forensics(tmp_dir, monkeypatch, report, 1)
+
+        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
+
+        assert len(rendered_findings(findings)) == 5
+
+    def test_the_cap_is_not_paid_when_it_does_not_bite(self, tmp_dir, tmp_path, monkeypatch):
+        """No overflow line on a report that fits, so it cannot become noise."""
+        report = aggregate_report(tmp_path, [
+            scanner_result("skill_threats", [
+                finding(severity="high", title=f"Finding {n}") for n in range(5)
+            ], exit_code=1),
+        ])
+        stub_forensics(tmp_dir, monkeypatch, report, 1)
+
+        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
+
+        assert len(rendered_findings(findings)) == 5
+        assert overflow_lines(findings) == []
+
+    def test_overflow_line_carries_the_hidden_count_and_breakdown(
+        self, tmp_dir, tmp_path, monkeypatch
+    ):
+        """A capped report must never be mistakable for a complete one.
+
+        Two CRITICAL and three HIGH fill the cap exactly, so the four MEDIUM
+        are the hidden set and the breakdown is checkable rather than
+        approximate.
+        """
+        report = aggregate_report(tmp_path, [
+            scanner_result(
+                "skill_threats",
+                [finding(severity="critical", title=f"Crit {n}") for n in range(2)]
+                + [finding(severity="high", title=f"High {n}") for n in range(3)]
+                + [finding(severity="medium", title=f"Med {n}") for n in range(4)],
+                exit_code=2,
+            ),
+        ])
+        stub_forensics(tmp_dir, monkeypatch, report, 2)
+
+        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
+
+        overflow = overflow_lines(findings)
+        assert len(overflow) == 1
+        assert findings[-1] == overflow[0]
+        assert "4" in overflow[0]
+        assert "MEDIUM" in overflow[0]
+        # The breakdown describes what was hidden, not what was shown.
+        assert "CRITICAL" not in overflow[0] and "HIGH" not in overflow[0]
+
+    def test_findings_are_sorted_by_severity_in_the_reader(
+        self, tmp_dir, tmp_path, monkeypatch
+    ):
+        """Worst first, and not because the producer happened to say so."""
+        report = unsorted_report(tmp_path, [
+            finding(severity="medium", title="Middling"),
+            finding(severity="high", title="Bad"),
+            finding(severity="critical", title="Worst"),
+        ])
+        # The premise of the assertion below, not an incidental property: a
+        # reader that took the producer's order would render MEDIUM first.
+        assert report["findings"][0]["title"] == "Middling"
+        stub_forensics(tmp_dir, monkeypatch, report, 2)
+
+        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
+
+        assert [line.split("]")[0] + "]" for line in rendered_findings(findings)] == [
+            "[CRITICAL]", "[HIGH]", "[MEDIUM]",
+        ]
+
+    def test_truncation_never_hides_the_worst_result(self, tmp_dir, tmp_path, monkeypatch):
+        """The cap bites on a report whose producer put the worst finding last."""
+        report = unsorted_report(tmp_path, (
+            [finding(severity="medium", title=f"Med {n}") for n in range(5)]
+            + [finding(severity="critical", title="The worst")]
+        ))
+        stub_forensics(tmp_dir, monkeypatch, report, 2)
+
+        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
+
+        shown = rendered_findings(findings)
+        assert len(shown) == 5
+        assert shown[0].startswith("[CRITICAL]")
+        assert "The worst" in shown[0]
+        overflow = overflow_lines(findings)
+        assert len(overflow) == 1
+        assert "1" in overflow[0] and "MEDIUM" in overflow[0]
+
+    def test_an_unrankable_severity_is_reported_rather_than_dropped(
+        self, tmp_dir, monkeypatch
+    ):
+        """A severity off the vocabulary must not be a way to go quiet.
+
+        Hand-written rather than built through `finding()`, because
+        `forensics_core.Finding` is not the only way a severity reaches a
+        report -- a scanner's raw JSON is, and `load_scanner_results()` copies
+        it through verbatim. If an unrecognised severity fell below the floor,
+        a scanned repository could suppress its own worst finding by writing
+        one, trading the false clean this work removes for a narrower one.
+        """
+        payload = {"scanners": [], "findings": [
+            {"severity": "sev-9", "title": "unrankable finding",
+             "description": "", "file": "a.py", "line": 1},
+            {"severity": "low", "title": "informational note",
+             "description": "", "file": "b.py", "line": 2},
+        ]}
+        stub_forensics(tmp_dir, monkeypatch, payload, 2)
+
+        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
+
+        assert len(rendered_findings(findings)) == 1
+        assert findings[0].startswith("[UNKNOWN] unrankable finding")
+        assert not any("informational note" in line for line in findings)
+
+    def test_an_unrankable_severity_sorts_below_every_ranked_one(
+        self, tmp_dir, monkeypatch
+    ):
+        """Reported, but never ahead of a finding the aggregator could rank.
+
+        The other half of the rule above: showing an unrankable severity must
+        not hand a scanned repository the top of the report, or the cap becomes
+        the suppression channel the floor was not.
+        """
+        payload = {"scanners": [], "findings": [
+            {"severity": "sev-9", "title": "unrankable finding",
+             "description": "", "file": "a.py", "line": 1},
+            {"severity": "medium", "title": "ranked finding",
+             "description": "", "file": "b.py", "line": 2},
+        ]}
+        stub_forensics(tmp_dir, monkeypatch, payload, 2)
+
+        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
+
+        shown = rendered_findings(findings)
+        assert len(shown) == 2
+        assert shown[0].startswith("[MEDIUM]")
+        assert shown[1].startswith("[UNKNOWN]")
+
+
 class TestAggregateReportContract:
     """Pin the aggregate report's shape against the aggregator that emits it.
 

--- a/skills/repo-forensics/tests/test_session_scan.py
+++ b/skills/repo-forensics/tests/test_session_scan.py
@@ -6,6 +6,7 @@ persistence, output formatting, edge cases, and latency verification.
 
 import json
 import os
+import shlex
 import sys
 import time
 import tempfile
@@ -46,6 +47,25 @@ def create_plugin(base_dir, name, version="1.0.0", deps=None):
         pkg = {"name": name, "version": version, "dependencies": deps}
         create_file(os.path.join(plugin_dir, "package.json"), json.dumps(pkg))
     return plugin_dir
+
+
+def stub_forensics(tmp_dir, monkeypatch, payload, exit_code):
+    """Point RUN_FORENSICS_SCRIPT at a stub that prints `payload` and exits.
+
+    The payload goes through a file rather than an inlined `echo`, so a report
+    carrying quotes, escapes or control bytes reaches deep_scan_item() as
+    written instead of being mangled by the shell. `payload` is a report dict
+    (serialised here) or a raw string for the unparseable cases.
+    """
+    payload_path = os.path.join(tmp_dir, "stub_payload.json")
+    text = payload if isinstance(payload, str) else json.dumps(payload)
+    with open(payload_path, "w", encoding="utf-8") as handle:
+        handle.write(text)
+    script = os.path.join(tmp_dir, "stub_forensics.sh")
+    create_file(script, f'#!/bin/bash\ncat {shlex.quote(payload_path)}\nexit {int(exit_code)}\n')
+    os.chmod(script, 0o755)
+    monkeypatch.setattr(session_scan, 'RUN_FORENSICS_SCRIPT', script)
+    return script
 
 
 @pytest.fixture
@@ -769,40 +789,6 @@ class TestDeepScanItem:
 
         assert findings == []
 
-    def test_critical_exit_with_json(self, tmp_dir, monkeypatch):
-        script = os.path.join(tmp_dir, "fake_forensics.sh")
-        output = json.dumps({
-            "summary": {"critical": 1},
-            "scanners": [
-                {"name": "runtime_behavior", "severity": "critical",
-                 "detail": "eval() with external input detected"}
-            ]
-        })
-        create_file(script, f'#!/bin/bash\necho \'{output}\'\nexit 2')
-        os.chmod(script, 0o755)
-        monkeypatch.setattr(session_scan, 'RUN_FORENSICS_SCRIPT', script)
-
-        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
-        assert len(findings) >= 1
-        assert any("CRITICAL" in f for f in findings)
-        assert any("eval()" in f for f in findings)
-
-    def test_warning_exit_with_json(self, tmp_dir, monkeypatch):
-        script = os.path.join(tmp_dir, "fake_forensics.sh")
-        output = json.dumps({
-            "scanners": [
-                {"name": "manifest_drift", "severity": "warning",
-                 "detail": "2 undeclared files found"}
-            ]
-        })
-        create_file(script, f'#!/bin/bash\necho \'{output}\'\nexit 1')
-        os.chmod(script, 0o755)
-        monkeypatch.setattr(session_scan, 'RUN_FORENSICS_SCRIPT', script)
-
-        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
-        assert len(findings) >= 1
-        assert any("WARNING" in f for f in findings)
-
     def test_timeout_returns_finding(self, tmp_dir, monkeypatch):
         script = os.path.join(tmp_dir, "slow_forensics.sh")
         create_file(script, '#!/bin/bash\nsleep 60\nexit 0')
@@ -844,6 +830,250 @@ class TestDeepScanItem:
         findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
         assert len(findings) >= 1
         assert any("CRITICAL" in f for f in findings)
+
+
+@_POSIX_ONLY
+class TestDeepScanFindingsReachTheSession:
+    """A changed item's deep-scan findings reach session start, sanitised.
+
+    Every report here is built by `aggregate_report()`, which drives the real
+    `aggregate_json.load_scanner_results()`, and is then fed back through a
+    stub `run_forensics.sh` into `deep_scan_item()`. Producer and consumer are
+    therefore pinned to each other by construction: no fixture in this class
+    can describe a report shape the aggregator does not emit, which is exactly
+    how the defect these tests cover survived a green suite.
+
+    Assertions are on what the hook returns. Nothing here reaches past
+    `deep_scan_item()` into the renderer.
+    """
+
+    def test_critical_finding_reaches_the_session(self, tmp_dir, tmp_path, monkeypatch):
+        """The defect, stated as a test: exit 2 on a CRITICAL used to print `clean`."""
+        report = aggregate_report(tmp_path, [
+            scanner_result("skill_threats", [finding(
+                severity="critical",
+                title="eval() on external input",
+                file="hooks/evil.py",
+                line=12,
+            )], exit_code=2),
+        ])
+        stub_forensics(tmp_dir, monkeypatch, report, 2)
+
+        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
+
+        assert len(findings) == 1
+        assert "CRITICAL" in findings[0]
+        assert "eval() on external input" in findings[0]
+
+    def test_one_display_line_per_finding(self, tmp_dir, tmp_path, monkeypatch):
+        report = aggregate_report(tmp_path, [
+            scanner_result("skill_threats", [
+                finding(severity="critical", title="First"),
+                finding(severity="high", title="Second"),
+            ], exit_code=2),
+            scanner_result("secrets", [
+                finding(severity="medium", title="Third", scanner="secrets"),
+            ], exit_code=1),
+        ])
+        stub_forensics(tmp_dir, monkeypatch, report, 2)
+
+        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
+
+        assert len(findings) == 3
+        assert any("First" in f for f in findings)
+        assert any("Second" in f for f in findings)
+        assert any("Third" in f for f in findings)
+
+    def test_severity_is_read_from_the_finding(self, tmp_dir, tmp_path, monkeypatch):
+        """The scanner entry has no severity to read; the finding does."""
+        report = aggregate_report(tmp_path, [
+            scanner_result("skill_threats", [
+                finding(severity="critical", title="Worst"),
+                finding(severity="medium", title="Middling"),
+            ], exit_code=2),
+        ])
+        # Restated here because it is the premise of the assertion below, not
+        # an incidental property: a reader looking for a scanner-level severity
+        # finds nothing and reports the item clean.
+        assert all("severity" not in entry for entry in report["scanners"])
+        stub_forensics(tmp_dir, monkeypatch, report, 2)
+
+        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
+
+        by_title = {line.split("]")[1].strip().split(" (")[0]: line for line in findings}
+        assert "CRITICAL" in by_title["Worst"]
+        assert "MEDIUM" in by_title["Middling"]
+
+    def test_severity_vocabulary_matches_the_aggregator(self):
+        """The hook mirrors the vocabulary instead of importing the aggregator.
+
+        A SessionStart hook on a 15s budget does not import a 1,200-line
+        scanner module for four strings -- but a mirror that drifts is how the
+        reader and the emitter came apart in the first place, so pin it.
+        """
+        assert set(session_scan.DEEP_FINDING_SEVERITIES) == set(aggregate_json.SEVERITY_ORDER)
+
+    def test_off_vocabulary_severity_cannot_forge_a_line(self, tmp_dir, monkeypatch):
+        """Severity is attacker-controlled too, and it is not sanitised text.
+
+        `load_scanner_results()` copies each scanner's JSON through verbatim
+        and validates no severity, so a scanned repository controls this field
+        exactly as it controls the title. It is rendered inside the `[...]`
+        tag that prefixes every line, so a newline here forges a top-level
+        line. Hand-written rather than built through `finding()`, because
+        `forensics_core.Finding` is not the only way a severity reaches a
+        report -- a scanner's raw JSON is.
+        """
+        payload = {"scanners": [], "findings": [{
+            "severity": "high\n[CRITICAL] forged top-level line",
+            "title": "real title", "description": "", "file": "a.py", "line": 1,
+        }]}
+        stub_forensics(tmp_dir, monkeypatch, payload, 2)
+
+        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
+
+        assert len(findings) == 1
+        assert "\n" not in findings[0]
+        assert findings[0].startswith("[UNKNOWN] real title")
+
+    def test_each_line_names_the_file_the_finding_sits_in(self, tmp_dir, tmp_path, monkeypatch):
+        report = aggregate_report(tmp_path, [
+            scanner_result("skill_threats", [finding(
+                severity="high", title="Injection", file="skills/thing/SKILL.md", line=7,
+            )], exit_code=1),
+        ])
+        stub_forensics(tmp_dir, monkeypatch, report, 1)
+
+        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
+
+        assert len(findings) == 1
+        assert "skills/thing/SKILL.md" in findings[0]
+
+    def test_hostile_finding_text_is_neutralised(self, tmp_dir, tmp_path, monkeypatch):
+        """Finding text comes out of the scanned tree and lands in agent context.
+
+        A repository that can forge a line in the session report can address
+        the agent that was inspecting it. Titles, descriptions and paths are
+        all attacker-controlled, so all three are checked.
+        """
+        report = aggregate_report(tmp_path, [
+            scanner_result("skill_threats", [finding(
+                severity="high",
+                title="benign\n[CRITICAL] forged top-level line",
+                description="\x1b[31mred\x1b[0m \u202eeslaf\u202c tail",
+                file="a/\u202egnp.exe\nsecond line",
+                line=3,
+            )], exit_code=1),
+        ])
+        stub_forensics(tmp_dir, monkeypatch, report, 1)
+
+        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
+
+        assert len(findings) == 1
+        line = findings[0]
+        assert "\n" not in line and "\r" not in line
+        # The whole escape, not just its ESC byte: `\x1b` alone is inside the
+        # C0 range every fallback strips, so asserting only that would pass on
+        # a sanitiser that leaves `[31m` sitting in the report as text.
+        assert "\x1b" not in line
+        assert "[31m" not in line and "[0m" not in line
+        assert not any(ch in line for ch in "\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069")
+        # Neutralised, not discarded: the report still says what was found.
+        assert "benign" in line
+
+    def test_hostile_text_is_neutralised_without_the_adjudication_module(
+        self, tmp_dir, tmp_path, monkeypatch
+    ):
+        """The stdlib fallback is the live path when `adjudication` is missing.
+
+        aggregate_json.format_report_as_text() carries the same fallback for
+        the same reason. Untested, it is a branch that only runs on the day
+        the import fails -- which is the worst day to discover it is wrong.
+        Setting the module entry to None is what makes `import adjudication`
+        raise ImportError.
+        """
+        monkeypatch.setitem(sys.modules, "adjudication", None)
+        report = aggregate_report(tmp_path, [
+            scanner_result("skill_threats", [finding(
+                severity="high",
+                title="benign\n[CRITICAL] forged top-level line",
+                description="\x1b[31mred\x1b[0m \u202eeslaf\u202c tail",
+                file="a/\u202egnp.exe\nsecond line",
+                line=3,
+            )], exit_code=1),
+        ])
+        stub_forensics(tmp_dir, monkeypatch, report, 1)
+
+        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
+
+        assert len(findings) == 1
+        line = findings[0]
+        assert "\n" not in line and "\r" not in line
+        assert "\x1b" not in line
+        assert not any(ch in line for ch in "\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069")
+        assert "benign" in line
+        # What the fallback does NOT do, recorded rather than left to be
+        # discovered: it is aggregate_json.format_report_as_text()'s fallback
+        # verbatim, so it strips the ESC byte but has no equivalent of
+        # adjudication._ORPHAN_SGR_RE and leaves the orphan parameters behind.
+        # Harmless as text, and narrowing the gap here would put a second,
+        # different neutralisation behaviour in the codebase -- which is the
+        # drift this ticket's criterion was written to prevent.
+        assert "[31m" in line
+
+    @pytest.mark.parametrize("payload", [
+        {"scanners": [], "findings": 5},
+        {"scanners": [], "findings": "not a list"},
+        {"scanners": [], "findings": [None, 7, "text"]},
+        {"scanners": [], "findings": [{"severity": None, "title": {"a": 1}, "line": "x"}]},
+    ])
+    @pytest.mark.parametrize("sink", [None, []], ids=["no-sink", "adjudication-sink"])
+    def test_malformed_report_never_raises_out_of_the_hook(
+        self, tmp_dir, monkeypatch, payload, sink
+    ):
+        """A report is a scanner's stdout, so any field can be any JSON type.
+
+        `deep_scan_item()` documents that it never raises, and SessionStart
+        depends on it: these payloads are well-formed JSON, so nothing is
+        raised for its `except (json.JSONDecodeError, ValueError)` to catch.
+        The call completing is the assertion.
+
+        Both sink states are driven because they are two readers of the same
+        field, and `main()` always passes a sink -- so a test that only ran
+        the default would be a check that could not go positive on the only
+        path that ships.
+        """
+        stub_forensics(tmp_dir, monkeypatch, payload, 2)
+
+        findings = session_scan.deep_scan_item(
+            tmp_dir, "test", "plugin", adjudication_sink=sink
+        )
+
+        assert all(isinstance(line, str) for line in findings)
+
+    def test_invented_report_shape_is_not_read_as_findings(self, tmp_dir, monkeypatch):
+        """The counter-example: the shape the broken reader believed in.
+
+        Hand-written on purpose. `load_scanner_results()` has never emitted a
+        scanner-level `severity`/`detail`, so nothing in this payload is a
+        finding and none of it may be rendered as one.
+
+        Whether such a scan is still allowed to report the item *clean* is
+        ticket 04's question, not this one.
+        """
+        payload = {
+            "summary": {"critical": 1},
+            "scanners": [
+                {"name": "runtime_behavior", "severity": "critical",
+                 "detail": "eval() with external input detected"},
+            ],
+        }
+        stub_forensics(tmp_dir, monkeypatch, payload, 2)
+
+        findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
+
+        assert not any("eval() with external input" in line for line in findings)
+        assert not any("runtime_behavior" in line for line in findings)
 
 
 class TestAggregateReportContract:

--- a/skills/repo-forensics/tests/test_session_scan.py
+++ b/skills/repo-forensics/tests/test_session_scan.py
@@ -15,7 +15,10 @@ import pytest
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), '..', 'scripts')
 sys.path.insert(0, os.path.abspath(SCRIPTS_DIR))
 
+import aggregate_json  # noqa: E402
 import session_scan  # noqa: E402
+
+from report_builders import aggregate_report, finding, scanner_result  # noqa: E402
 
 _POSIX_ONLY = pytest.mark.skipif(
     os.name == "nt", reason="POSIX shell/process behavior not available on Windows"
@@ -841,6 +844,111 @@ class TestDeepScanItem:
         findings = session_scan.deep_scan_item(tmp_dir, "test", "plugin")
         assert len(findings) >= 1
         assert any("CRITICAL" in f for f in findings)
+
+
+class TestAggregateReportContract:
+    """Pin the aggregate report's shape against the aggregator that emits it.
+
+    This class lives beside the SessionStart tests rather than in
+    test_aggregate_json.py because it exists for the *consumer*: session_scan
+    reads the report the aggregator writes, and the two drifted apart in
+    silence once already -- the deep scan read a scanner-level `severity` key
+    that `load_scanner_results()` has never emitted, so it collected nothing
+    and printed `clean` over a scan that exited 2 on a CRITICAL finding, while
+    a hand-written fixture kept the suite green.
+
+    Every assertion here is on the emitter's own output, so the class is green
+    on the unchanged base commit and goes red the moment the emitted shape
+    moves under a reader still expecting the old one. That is what makes it a
+    control arm: a reader that has stopped seeing findings must not be
+    indistinguishable from a target that has none.
+    """
+
+    def test_scanner_entry_carries_exactly_the_loader_keys(self, tmp_path):
+        critical = finding(severity="critical")
+        report = aggregate_report(tmp_path, [
+            scanner_result("skill_threats", [critical], exit_code=2),
+        ])
+
+        assert len(report["scanners"]) == 1
+        entry = report["scanners"][0]
+        assert set(entry) == {
+            "name", "exit_code", "parse_error", "finding_count", "findings",
+        }
+        assert entry["name"] == "skill_threats"
+        assert entry["exit_code"] == 2
+        assert entry["parse_error"] is None
+        assert entry["finding_count"] == 1
+        assert entry["findings"] == [critical]
+
+    def test_scanner_entry_carries_stderr_only_when_present(self, tmp_path):
+        report = aggregate_report(tmp_path, [
+            scanner_result("noisy", [finding()], stderr="warning: slow walk"),
+            scanner_result("quiet", [finding()]),
+        ])
+
+        entries = {entry["name"]: entry for entry in report["scanners"]}
+        assert entries["noisy"]["stderr"] == "warning: slow walk"
+        assert "stderr" not in entries["quiet"]
+
+    def test_scanner_entry_carries_no_severity_detail_or_message(self, tmp_path):
+        """The three keys the broken reader looked for. None is ever emitted."""
+        report = aggregate_report(tmp_path, [
+            scanner_result("skill_threats", [finding(severity="critical")], exit_code=2),
+            scanner_result("secrets", [finding(severity="high")], exit_code=1),
+            scanner_result("binary", [], exit_code=0),
+        ])
+
+        for entry in report["scanners"]:
+            assert "severity" not in entry
+            assert "detail" not in entry
+            assert "message" not in entry
+
+    def test_severity_lives_on_each_finding_with_the_report_vocabulary(self, tmp_path):
+        report = aggregate_report(tmp_path, [
+            scanner_result("skill_threats", [
+                finding(severity="critical"),
+                finding(severity="high", title="H"),
+                finding(severity="medium", title="M"),
+                finding(severity="low", title="L"),
+            ], exit_code=2),
+        ])
+
+        # The vocabulary is the aggregator's, not this test's.
+        assert set(aggregate_json.SEVERITY_ORDER) == {
+            "critical", "high", "medium", "low",
+        }
+        assert len(report["findings"]) == 4
+        for item in report["findings"]:
+            assert item["severity"] in aggregate_json.SEVERITY_ORDER
+        assert {item["severity"] for item in report["findings"]} == {
+            "critical", "high", "medium", "low",
+        }
+
+    def test_builder_entries_match_a_real_build_report(self, tmp_path):
+        """The builder stops at the loader; prove that costs no fidelity.
+
+        aggregate_report() assembles a report from load_scanner_results() plus
+        the two pure scorers instead of calling build_report(), so that a
+        fixture's findings are not rewritten by correlation and evidence
+        capping. If build_report() ever gave its scanner entries a different
+        shape, that shortcut would become a drift of its own -- so compare the
+        two directly.
+        """
+        results_dir = tmp_path / "results"
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+
+        built = aggregate_report(results_dir, [
+            scanner_result("skill_threats", [finding(severity="critical")], exit_code=2),
+            scanner_result("secrets", [finding(severity="high")], stderr="note", exit_code=1),
+        ])
+        real = aggregate_json.build_report(str(results_dir), str(repo_dir), "false")
+
+        real_entries = {entry["name"]: entry for entry in real["scanners"]}
+        for entry in built["scanners"]:
+            assert entry["name"] in real_entries
+            assert set(entry) == set(real_entries[entry["name"]])
 
 
 @_POSIX_ONLY

--- a/skills/repo-forensics/tests/test_session_scan.py
+++ b/skills/repo-forensics/tests/test_session_scan.py
@@ -1108,12 +1108,10 @@ class TestSessionReportIsBounded:
     """The session report carries only what could change what the owner does.
 
     Two limits are asserted here, and they bound different things. The
-    **floor** bounds what is worth a line at all: an informational note must
-    not turn every plugin update into a warning line, or the report stops
-    being read, and a report that is not read reports nothing. The **cap**
-    bounds how many lines one item can occupy: the return value of this hook
-    is echoed into the agent's session context, so a report with no ceiling
-    pushes the rest of the session out of the window.
+    **floor**, `DEEP_FINDING_REPORT_FLOOR`, bounds what is worth a line at
+    all; the **cap**, `DEEP_FINDING_MAX_LINES`, bounds how many lines one item
+    may occupy -- see each constant in `session_scan.py`, which explains why it
+    is there. What is asserted here is the behaviour.
 
     Both are lossy, so both are made visible: a capped report says how much it
     is hiding and at what severities, and the reader sorts before it truncates


### PR DESCRIPTION
This carries a rule the project already holds into two code paths that never received it.

**The rule, in the project's own words.** `CHANGELOG.md` (2.14.3, under *"Security: fail-closed on
the Cursor blocking path"*) states it as **"A gate that cannot run denies"** — a missing interpreter
or a crashed scanner produced *"a bare non-zero exit with no verdict, which is exactly the ambiguity
`failClosed` exists to resolve."* `.cursor/rules/repo-forensics.mdc` states it operationally:
*"Exit codes: `0` clean, `1` warn, `2` block, `99` the scan itself failed. Treat `2` as 'do not
install'; treat `99` as 'no verdict', never as 'clean'."* And it is not only documented, it is pinned
by a test — `tests/test_cursor_wiring.py`, `TestWrapperFailClosedOnBrokenInterpreter`: *"a gate that
cannot run must not approve."*

That treatment was applied to the Cursor pre-scan wrapper. Two other automatic paths still print
`clean` in exactly the situations the rule names. Neither fix proposes anything new; each applies the
existing rule where it was missing.

### Defect 1 — SessionStart reads severity from a field the aggregator never writes

`scripts/session_scan.py` looked for a severity on each entry of `report["scanners"]`. Entries there
carry `name`, `exit_code`, `parse_error`, `finding_count`, `findings` and sometimes `stderr` — never
a severity. The reader therefore collected nothing and printed `clean` over a scan that had exited
`2` on a CRITICAL finding. Severity is now read from each finding, which is the only place the
aggregator puts one.

Because those fields originate in the scanned tree and the hook's return value is echoed into the
agent's session context, the findings are neutralised on the way out: free text goes through the same
sanitiser `aggregate_json.format_report_as_text()` and `adjudication.build_adjudication_block()`
already use, and the severity — a four-word vocabulary, not free text — is checked against that
vocabulary rather than sanitised. Reporting the findings without that step would have traded a false
clean for an injection path into SessionStart.

The report is then bounded, because it competes with the session for one context window: a floor
(`critical`/`high`/`medium`; `low` is an informational note), a cap of five finding lines per changed
item, and one overflow line carrying the hidden count and a per-severity breakdown, so a truncated
report never looks like a complete one. Sorting happens in the reader rather than being taken from
the report — the report is a scanner's stdout, and truncating on a trusted order would let a producer
decide which finding the owner never sees.

### Defect 2 — the forensify driver turns a verdict into an error

`skills/forensify/orchestrator/scanner_driver.py` treated any non-zero scanner exit as a failure and
discarded the report. Exit `2` is not a failure; it is the verdict *block*. The driver now returns
the report for `0`, `1` and `2`, and fails only on `99` and on codes it does not recognise — which is
`.cursor/rules`' first clause, applied where it was missing.

### One deliberate behaviour change, kept separate on purpose

`feat(session-scan)!: a nonzero scan that renders nothing says so, and is not cleared` is **not** a
bug fix and is the fourth commit of nine, so it can be dropped without losing the two fixes above.

Previously, a deep scan ending non-zero while producing no renderable line returned nothing:
`format_output()` printed `clean` over it and `main()` wrote the item into the baseline. Past the
early returns for exit `0` and for a signal death — the two cases that legitimately render nothing —
an empty finding list now means the scan ended non-zero and the reader could not turn it into a line.
That is `.cursor/rules`' second clause almost verbatim: `99` is *no verdict*, not *clean*. One line
naming the exit code is emitted (an integer from `waitpid` and nothing else; it deliberately does not
start with `[`, so it cannot be mistaken for a finding line), and the item is left out of the
baseline — because `detect_changes()` reports only items whose hashes moved, so baselining an item
that was never cleared turns one failure the owner could act on into a permanent one they never see
again.

**If you would rather not take this one, it drops cleanly and the two fixes stand.** Three residual
paths that also baseline an unscanned item are named in that commit's message rather than fixed here,
because each is outside *"a scan that exits non-zero"* and closing them would widen the change past
what one commit can be argued on.

### The two defects are independent and separable on request

They share **no file** — `comm -12` over the two commit groups' file lists is empty. Defect 1 touches `skills/repo-forensics/scripts/session_scan.py` and its tests; defect 2
touches `skills/forensify/orchestrator/scanner_driver.py` and its tests. Say the word and this
becomes two pull requests.

### About the red `Verify manifest signature` job

`Verify Checksums` has two steps. The first, `Verify checksums`, **passes** — `checksums.json` was
regenerated with `verify_install.py --generate` and all 80 files match. The second, `Verify manifest
signature`, **fails, and cannot be made to pass from here**: `checksums.json.sig` needs your offline
release seed. The workflow's own error text says as much, and `tests.yml` already deselects
`test_shipped_manifest_signature_verifies` for the same reason. It is a hand-off, not something to
investigate.

One consequence worth naming, because it is the step the workflow puts between the two this branch
ran. Its shipping order is *regenerate checksums → re-sign `.sig` → re-run
`scripts/sync_codex_marketplace_plugin.sh`*. Steps 1 and 3 are done here, in that order, so the
mirror carries the fresh manifest. Step 2 is yours — and **when you re-sign, the sync has to be
re-run afterwards or `plugins/repo-forensics/` keeps the old signature.** Nothing tests that pairing:
`test_tree_parity.py` compares only `skills/repo-forensics/`'s `scripts/` and `data/`, and
`test_codex_marketplace.py` asserts only that forensify's `SKILL.md` exists.

`checksums.json.sig` itself is untouched — the same blob `948c8d0` in all four positions, canonical
and mirror, at `main` and at this branch's head.

### Commits

| | commit | what it is |
|---|---|---|
| 1 | `test(session-scan): build report fixtures from the aggregator and pin its shape` | tests only — a positive control, no production change |
| 2 | `fix(session-scan): read findings, not scanner severity, and sanitise them` | **defect 1** |
| 3 | `feat(session-scan): give the session report a floor, a cap and an overflow line` | bounds the report |
| 4 | `feat(session-scan)!: a nonzero scan that renders nothing says so, and is not cleared` | **the behaviour change** |
| 5 | `fix(forensify): return the report for exit 0, 1 and 2; fail only on 99 and the unforeseen` | **defect 2** |
| 6 | `chore: regenerate checksums.json and re-sync the marketplace mirror` | generated output only |
| 7 | `docs(session_scan): argue the report's bounds on this tool's own mechanics` | comments/docstrings + one test class name |
| 8 | `docs(session_scan): state each report bound's reason once, at its constant` | comments/docstrings |
| 9 | `docs(session_scan): reword to positive control and false-clean, upstream's own terms` | comments/docstrings |

Commits 7, 8 and 9 change no executable line, checked by AST comparison with docstrings blanked
against each commit's own parent: identical in every hand-edited file except commit 7's
`test_session_scan.py`, whose sole non-docstring change is the class rename
`TestSessionReportFrictionBudget` → `TestSessionReportIsBounded` that commit 7's message describes.

Commit 6 is purely generated — the mirror plus both `checksums.json` — and is the only commit that
syncs the forensify half of the mirror. Commits 7, 8 and 9 each re-run the two generators on top of
their own prose edit, so the manifest is current at the tip.

### Tests

Python 3.12 via `uv`, pytest from the hash-locked runner in `.github/requirements/pytest.txt`.
**Both arms run 2026-09-06**, branch and base, on the same machine and the same interpreter, in
detached worktrees at each rev:

| suite | base `cfb7679` | branch `730caf9` |
|---|---|---|
| `skills/repo-forensics/tests/` | 3328 passed, 94 skipped, **0 failed** | 3367 passed, 94 skipped, **1 failed** |
| `skills/forensify/tests/` | 108 passed, **1 failed** | 121 passed, **1 failed** |

**The branch adds 39 passing repo-forensics tests and 13 passing forensify tests, and introduces
exactly one new failure:** `test_manifest_signature.py::test_shipped_manifest_signature_verifies` —
the signing hand-off described above, and the same test `tests.yml` deselects. It is green at the
base and red on the branch precisely because the manifest was regenerated and the signature was not
re-signed.

**The forensify failure is not this branch's**, and the base arm is what shows it:
`TestSeatbeltSandbox::test_seatbelt_profile_parseable` fails identically at `cfb7679`. It shells out
to `sandbox-exec`, which this machine denies (`execvp() of 'python3' failed: Operation not
permitted`). The whole class is `@pytest.mark.skipif(platform.system() != "Darwin")`, so it does not
run on Linux CI at all.

Every assertion added by the two fixes was demonstrated to go red under a mutation of the code it
pins.
