### PR TITLE
fix(binary): validate PE structure before flagging audio steganography

### DIFF
--- a/plugins/repo-forensics/skills/repo-forensics/scripts/scan_binary.py
+++ b/plugins/repo-forensics/skills/repo-forensics/scripts/scan_binary.py
@@ -49,6 +49,28 @@ _EXEC_DESCS = {'ELF Executable (Linux)', 'PE Executable (Windows)',
 EXEC_SIGNATURES = [sig for sig, desc in MAGIC_NUMBERS.items() if desc in _EXEC_DESCS]
 
 
+def _is_valid_pe(content, offset):
+    """A real PE has 'PE\\x00\\x00' at the location its e_lfanew field points to.
+    A bare 'MZ' pair (2 bytes) appears routinely inside compressed audio,
+    so require the structural marker too before treating it as an executable."""
+    if offset + 0x40 > len(content):
+        return False
+    e_lfanew = int.from_bytes(content[offset + 0x3C:offset + 0x40], "little")
+    return 0 < e_lfanew < 4096 and content[e_lfanew:e_lfanew + 4] == b'PE\x00\x00'
+
+
+def _find_embedded_executable(content, search_from):
+    """Return the first offset of a valid executable signature in content, else None."""
+    for sig in EXEC_SIGNATURES:
+        offset = content.find(sig, search_from)
+        while offset > 0:
+            if sig == b'MZ' and not _is_valid_pe(content, offset):
+                offset = content.find(sig, offset + 1)
+                continue
+            return offset
+    return None
+
+
 def scan_audio_steganography(filepath, rel_path):
     """Detect executable content hidden in audio files (TeamPCP Telnyx attack pattern, March 2026).
 
@@ -68,18 +90,16 @@ def scan_audio_steganography(filepath, rel_path):
         with open(filepath, 'rb') as f:
             content = f.read(min(file_size, 128 * 1024))
 
-        for sig in EXEC_SIGNATURES:
-            offset = content.find(sig, 44 if ext == '.wav' else 0)
-            if offset > 0:
-                findings.append(core.Finding(
-                    scanner=SCANNER_NAME, severity="critical",
-                    title=f"Audio Steganography: Executable in {ext.upper()}",
-                    description=f"Audio file contains executable signature at offset {offset} (TeamPCP Telnyx attack pattern, March 2026). Malicious code hidden in audio data frames.",
-                    file=rel_path, line=0,
-                    snippet=f"Executable signature found at byte offset {offset}",
-                    category="audio-steganography"
-                ))
-                break
+        offset = _find_embedded_executable(content, 44 if ext == '.wav' else 0)
+        if offset is not None:
+            findings.append(core.Finding(
+                scanner=SCANNER_NAME, severity="critical",
+                title=f"Audio Steganography: Executable in {ext.upper()}",
+                description=f"Audio file contains executable signature at offset {offset} (TeamPCP Telnyx attack pattern, March 2026). Malicious code hidden in audio data frames.",
+                file=rel_path, line=0,
+                snippet=f"Executable signature found at byte offset {offset}",
+                category="audio-steganography"
+            ))
 
         data_section = content[44:] if ext == '.wav' else content[128:]
         if len(data_section) > 100:


### PR DESCRIPTION
## The bug

`scan_audio_steganography` flags **any** nonzero-offset occurrence of the byte pairs in `EXEC_SIGNATURES` inside the first 128 KB of an audio file as `critical` "Executable in .OGG/.MP3".

The worst offender is `b'MZ'` — a **2-byte** magic. Compressed audio (MP3/Ogg frame data, WAV samples) is entropy-coded, so any 2-byte sequence reappears roughly every 65 KB by pure chance. Normal audio fixtures routinely trip this finding at `critical` severity.

Example: a `sine_440hz_44k.mp3` test fixture (raw sine tone compressed as MP3) is flagged as "Audio Steganography: Executable in .MP3" purely because the two bytes `MZ` occur inside an audio frame at offset 7259.

## Why real payloads still need a lower bar than this

A real Windows PE embedded in audio does **not** consist of a bare `MZ`. It also carries the `e_lfanew` pointer at `MZ + 0x3C` that must point (within reason) at the `PE\x00\x00` signature. Requiring both kills the random-noise false positives while leaving genuine embedded payloads (including the TeamPCP pattern this check targets) detectable.

## The fix

- Keep the existing scan loop for ELF / Mach-O / Java magics unchanged (all are ≥ 4 bytes; chance hits in compressed data are negligible).
- For `MZ`, additionally require:
  - a readable 4-byte `e_lfanew` at `MZ + 0x3C`,
  - `0 < e_lfanew < 4096`,
  - `PE\x00\x00` at `content[e_lfanew]`.

## Verification

- `two_speakers_de.ogg`, `two_speakers_de.mp3`, `sine_440hz_44k.mp3` (real fixtures): **no longer flagged**.
- Crafted pseudo-audio with a structurally valid embedded PE: **still flagged**.
- Same bytes with the `PE\x00\x00` signature removed: **quiet**.